### PR TITLE
Changed main Makefile to put LDFLAGS after -lbamtools. Fixes customized ...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ BUILT_OBJECTS = $(OBJ_DIR)/*.o
 all: print_banner $(OBJ_DIR) $(BIN_DIR) autoversion $(UTIL_SUBDIRS) $(SUBDIRS)
 	@echo "- Building main bedtools binary."
 	@$(CXX) $(CXXFLAGS) -c src/bedtools.cpp -o obj/bedtools.o -I$(UTIL_DIR)/version/
-	@$(CXX) $(LDFLAGS) $(CXXFLAGS) -o $(BIN_DIR)/bedtools $(BUILT_OBJECTS) -L$(UTIL_DIR)/BamTools/lib/ -lbamtools $(LIBS)
+	@$(CXX) $(CXXFLAGS) -o $(BIN_DIR)/bedtools $(BUILT_OBJECTS) -L$(UTIL_DIR)/BamTools/lib/ -lbamtools $(LIBS) $(LDFLAGS)
 	@echo "done."
 	
 	@echo "- Creating executables for old CLI."


### PR DESCRIPTION
...Bamtools link error when Bamtools already defined in /usr/lib.
