### PR TITLE
Update installation.rst

### DIFF
--- a/docs/content/installation.rst
+++ b/docs/content/installation.rst
@@ -76,7 +76,11 @@ package manager for OSX.
     
     brew install bedtools
 
+**MacPorts**. Alternatively, the MacPorts ports system can be used to install BEDTools on OSX.
 
+.. code-block:: bash
+
+    port install bedtools
 
 -----------------------------
 Development versions


### PR DESCRIPTION
added macports as an option for installing bedtools on mac os x.
