### PR TITLE
support for operators 'X' and '=' in method BlockedIntervals.cpp/GetBamB...

### DIFF
--- a/src/utils/BlockedIntervals/BlockedIntervals.cpp
+++ b/src/utils/BlockedIntervals/BlockedIntervals.cpp
@@ -33,7 +33,7 @@ void GetBamBlocks(const BamAlignment &bam,
     vector<CigarOp>::const_iterator cigEnd = bam.CigarData.end();
     for (; cigItr != cigEnd; ++cigItr) {
         switch (cigItr->Type) {
-            case ('M') :
+            case ('M') :case ('X'): case ('='):
                 blockLength += cigItr->Length;
             case ('I') : break;
             case ('S') : break;
@@ -58,7 +58,7 @@ void GetBamBlocks(const BamAlignment &bam,
                 }
             case ('H') : break;                             // for 'H' - do nothing, move to next op
             default    :
-                printf("ERROR: Invalid Cigar op type\n");   // shouldn't get here
+                fprintf(stderr,"ERROR: Invalid Cigar op type \'%c\'.\n",cigItr->Type);   // shouldn't get here
                 exit(1);
         }
     }


### PR DESCRIPTION
used bamToBed with a bam containing cigar-operators 'X' and '='. The method  `GetBamBlocks` in BlockedIntervals.cpp doesn't support those operators.
