### PR TITLE
Update links in docs to point to the bedtools2 github pages.

### DIFF
--- a/docs/content/installation.rst
+++ b/docs/content/installation.rst
@@ -3,10 +3,10 @@ Installation
 ############
 
 
-``bedtools`` is intended to run in a "command line" environment on UNIX, LINUX 
-and Apple OS X operating systems. Installing ``bedtools`` involves either 
-downloading the source code and compiling it manually, or installing stable 
-release from package managers such as 
+``bedtools`` is intended to run in a "command line" environment on UNIX, LINUX
+and Apple OS X operating systems. Installing ``bedtools`` involves either
+downloading the source code and compiling it manually, or installing stable
+release from package managers such as
 `homebrew (for OS X) <http://mxcl.github.com/homebrew/>`_.
 
 
@@ -20,14 +20,14 @@ Installing stable releases
 Compiling from source via Google Code
 .....................................
 
-Stable, versioned releases of bedtools are made available The following commands 
-will install ``bedtools`` in a local directory on an UNIX or OS X machine. 
-Note that the **"<version>"** refers to the latest posted version number 
+Stable, versioned releases of bedtools are made available The following commands
+will install ``bedtools`` in a local directory on an UNIX or OS X machine.
+Note that the **"<version>"** refers to the latest posted version number
 on http://bedtools.googlecode.com/.
 
 .. note::
 
-    The bedtools Makefiles utilize the GCC compiler. One should edit the 
+    The bedtools Makefiles utilize the GCC compiler. One should edit the
     Makefiles accordingly if one wants to use a different compiler.
 
 .. code-block:: bash
@@ -36,10 +36,10 @@ on http://bedtools.googlecode.com/.
   $ tar -zxvf BEDTools.tar.gz
   $ cd BEDTools-<version>
   $ make
-  
-At this point, one should copy the binaries in ./bin/ to either 
-``usr/local/bin/`` or some other repository for commonly used UNIX tools in 
-your environment. You will typically require administrator (e.g. "root" or 
+
+At this point, one should copy the binaries in ./bin/ to either
+``usr/local/bin/`` or some other repository for commonly used UNIX tools in
+your environment. You will typically require administrator (e.g. "root" or
 "sudo") privileges to copy to ``usr/local/bin/``. If in doubt, contact you
 system administrator for help.
 
@@ -48,11 +48,11 @@ Installing with package managers
 .....................................
 
 In addition, stable releases of ``bedtools`` are also available through package
-managers such as `homebrew (for OS X) <http://mxcl.github.com/homebrew/>`_, 
+managers such as `homebrew (for OS X) <http://mxcl.github.com/homebrew/>`_,
 ``apt-get`` and ``yum``.
 
-**Fedora/Centos**. Adam Huffman has created a Red Hat package for bedtools so 
-that one can easily install the latest release using "yum", the Fedora 
+**Fedora/Centos**. Adam Huffman has created a Red Hat package for bedtools so
+that one can easily install the latest release using "yum", the Fedora
 package manager. It should work with Fedora 13, 14 and EPEL5/6 (
 for Centos, Scientific Linux, etc.).
 
@@ -60,8 +60,8 @@ for Centos, Scientific Linux, etc.).
 
     yum install BEDTools
 
-**Debian/Ubuntu.** Charles Plessy also maintains a Debian package for bedtools 
-that is likely to be found in its derivatives like Ubuntu. Many thanks to 
+**Debian/Ubuntu.** Charles Plessy also maintains a Debian package for bedtools
+that is likely to be found in its derivatives like Ubuntu. Many thanks to
 Charles for doing this.
 
 .. code-block:: bash
@@ -69,11 +69,11 @@ Charles for doing this.
     apt-get install bedtools
 
 
-**Homebrew**. Carlos Borroto has made BEDTools available on the bedtools 
+**Homebrew**. Carlos Borroto has made BEDTools available on the bedtools
 package manager for OSX.
 
 .. code-block:: bash
-    
+
     brew install bedtools
 
 **MacPorts**. Alternatively, the MacPorts ports system can be used to install BEDTools on OSX.
@@ -86,11 +86,11 @@ package manager for OSX.
 Development versions
 -----------------------------
 
-The development version of bedtools is maintained in a Github 
-`repository <https://www.github.com/arq5x/bedtools>`_. Bug fixes are addressed
+The development version of bedtools is maintained in a Github
+`repository <https://www.github.com/arq5x/bedtools2>`_. Bug fixes are addressed
 in this repository prior to release, so there may be situations where you will
-want to use a development version of bedtools prior to its being promoted to 
-a stable release.  One would either clone the repository with ``git``, as 
+want to use a development version of bedtools prior to its being promoted to
+a stable release.  One would either clone the repository with ``git``, as
 follows and then compile the source code as describe above:
 
 .. code-block:: bash
@@ -98,7 +98,7 @@ follows and then compile the source code as describe above:
     git clone https://github.com/arq5x/bedtools2.git
 
 
-or, one can download the source code as a ``.zip`` file using the Github 
+or, one can download the source code as a ``.zip`` file using the Github
 website.  Once the zip file is downloaded and uncompressed with the ``unzip``
 command, one can compile and install using the instructions above.
 

--- a/docs/templates/page.html
+++ b/docs/templates/page.html
@@ -5,7 +5,7 @@
 
 {# note, currently these must be set... #}
 {% set github_base_account = 'arq5x' %}
-{% set github_project = 'bedtools' %}
+{% set github_project = 'bedtools2' %}
 
 {##################################################}
 {# for plone-derived "edit me" & Google analytics #}
@@ -137,4 +137,3 @@
 {% endif %}
 
 {%- endblock %}
-

--- a/docs/templates/sidebar-intro.html
+++ b/docs/templates/sidebar-intro.html
@@ -3,9 +3,9 @@
 </p>
 <h3>Bedtools links</h3>
 <ul>
-  <li><a target="_blank" href="https://github.com/arq5x/bedtools/issues">Issue Tracker</a></li>
-  <li><a target="_blank" href="https://github.com/arq5x/bedtools">Source @ GitHub</a></li>
-  <li><a target="_blank" href="https://bedtools.googlecode.com">Releases @ Google Code</a></li>
+  <li><a target="_blank" href="https://github.com/arq5x/bedtools2/issues">Issue Tracker</a></li>
+  <li><a target="_blank" href="https://github.com/arq5x/bedtools2">Source @ GitHub</a></li>
+  <li><a target="_blank" href="https://bedtools.googlecode.com">Old Releases @ Google Code</a></li>
   <li><a target="_blank" href="http://groups.google.com/group/bedtools-discuss">Mailing list @ Google Groups</a></li>
   <li><a target="_blank" href="http://www.biostars.org/show/tag/bedtools/">Queries @ Biostar</a></li>
   <li><a target="_blank" href="http://quinlanlab.org">Quinlan lab @ UVa</a></li>
@@ -13,10 +13,9 @@
 </ul>
 
 <h3>Sources</h3>
-<p><a href="https://github.com/arq5x/bedtools">Browse source @ GitHub</a>.</p>
+<p><a href="https://github.com/arq5x/bedtools2">Browse source @ GitHub</a>.</p>
 
 <h3>Releases</h3>
 <ul>
-    <li><a href="https://github.com/arq5x/bedtools2/releases">Stable releasees now @ Github</a></li>
+    <li><a href="https://github.com/arq5x/bedtools2/releases">Stable releases now @ Github</a></li>
 </ul>
-


### PR DESCRIPTION
The documentation hosted at RTD points to https://github.com/arq5x/bedtools when it should point to https://github.com/arq5x/bedtools2
