### PR TITLE
Fix CXXFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ export CXX		= g++
 #ifeq ($(DEBUG),1)
 #export CXXFLAGS = -Wall -O0 -g -fno-inline -fkeep-inline-functions -D_FILE_OFFSET_BITS=64 -fPIC -DDEBUG -D_DEBUG
 #else
-export CXXFLAGS = -Wall -O2 -D_FILE_OFFSET_BITS=64 -fPIC $(if $(INCLUDE),-I) $(INCLUDE)
+export CXXFLAGS = -Wall -O2 -D_FILE_OFFSET_BITS=64 -fPIC $(INCLUDES)
 #endif
 export LIBS		= -lz
 export BT_ROOT  = src/utils/BamTools/


### PR DESCRIPTION
I think -I is required before $(INCLUDE).
Especially I had compiler error in intel-compiler-enabled environment, where $(INCLUDE) is "/opt/intel/Compiler/13.1/192/composer_xe_2013.5.192/mkl/include:/opt/intel/Compiler/13.1/192/composer_xe_2013.5.192/mkl/include".
