### PR TITLE
Update merge.rst

### DIFF
--- a/docs/content/tools/merge.rst
+++ b/docs/content/tools/merge.rst
@@ -113,9 +113,9 @@ The ``-s`` option will only merge intervals that are overlapping/bookended
   chr1  501  1000  a4  4 +
 
   $ bedtools merge -i A.bed -s
-  chr1  100  250    +
-  chr1  501  1000   +
-  chr1  250  500    -
+  chr1  100  250
+  chr1  501  1000
+  chr1  250  500
 
 ==========================================================================
 ``-S`` Reporting merged intervals on a specific strand. 


### PR DESCRIPTION
to make consistent the doc and the behavior in the current stable release.
- or - were reported in column 4th in previous versions (eg. bedtools_2.14.3-1_amd64.deb) but not in the bedtools2-2.20.1 release.
