### PR TITLE
Fixed problem with negative mapping distances bedtools

### DIFF
--- a/src/genomeCoverageBed/genomeCoverageBed.cpp
+++ b/src/genomeCoverageBed/genomeCoverageBed.cpp
@@ -122,6 +122,9 @@ void BedGenomeCoverage::StartNewChrom(const string& newChrom) {
 void BedGenomeCoverage::AddCoverage(int start, int end) {
     // process the first line for this chromosome.
     // make sure the coordinates fit within the chrom
+    if (start < 0){
+        start = 0;
+    }
     if (start < _currChromSize)
         _currChromCoverage[start].starts++;
     if (end < _currChromSize)


### PR DESCRIPTION
This was a problem in a Bam I generated, using BWA where the read had a start position == 0.

HWUSI-EAS1599_0001:8:116:8882:17709#0   113     chr10   0       25      75M     chr1    36082549        0       CCTTAAACCCTAAACCCTAATCCCTAAACCCTAAACCCTAAACCCTTAAGCCTAAACCCTAAACCC.

Created downstream problems when calculating coverage as it left me with summaries with regions of the genome having -1 reads mapping within.
