### PR TITLE
adds make install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ export CXXFLAGS = -Wall -O2 -D_FILE_OFFSET_BITS=64 -fPIC $(INCLUDES)
 export LIBS		= -lz
 export BT_ROOT  = src/utils/BamTools/
 
+prefix = /usr/local
+
 SUBDIRS = $(SRC_DIR)/annotateBed \
 		  $(SRC_DIR)/bamToBed \
 		  $(SRC_DIR)/bamToFastq \
@@ -106,6 +108,12 @@ all: print_banner $(OBJ_DIR) $(BIN_DIR) autoversion $(UTIL_SUBDIRS) $(SUBDIRS)
 	
 
 .PHONY: all
+
+install: all
+	mkdir -p $(DESTDIR)$(prefix)/bin
+	for file in bin/* ; do \
+		cp -f $$file $(DESTDIR)$(prefix)/bin; \
+	done
 
 print_banner:
 	@echo "Building BEDTools:"


### PR DESCRIPTION
This commit adds an `install` target to `Makefile`. It is configurable by `prefix` (defaults to `/usr/local`) as well as `DESTDIR` (defaults to empty).

Thus:
-   install to `/usr/local`:
  
  ```
  make install
  ```
-   install to `/usr`:
  
  ```
  make prefix=/usr install
  ```
-   install to `/usr` with another destination directory:
  
  ```
  make prefix=/usr DESTDIR=$HOME/apps/bioinf install
  ```

The target depends on `all` and copies it to the `bin` directory within `prefix`.
