### PR TITLE
Corrected error in reporting amount of overlap (issue #150)

### DIFF
--- a/src/utils/FileRecordTools/Records/BlockMgr.cpp
+++ b/src/utils/FileRecordTools/Records/BlockMgr.cpp
@@ -190,9 +190,9 @@ int BlockMgr::findBlockedOverlaps(RecordKeyVector &keyList, RecordKeyVector &hit
 			}
 		}
 		if (hitHasOverlap) {
-			if ((float) totalHitOverlap / (float)keyBlocksSumLength > _overlapFraction) {
+			if ((float) totalHitOverlap / (float)keyBlocksSumLength >= _overlapFraction) {
 				if (_hasReciprocal &&
-						((float)totalHitOverlap / (float)hitBlockSumLength > _overlapFraction)) {
+						((float)totalHitOverlap / (float)hitBlockSumLength >= _overlapFraction)) {
 					_overlapBases.push_back(totalHitOverlap);
 					resultList.push_back(*hitListIter);
 				} else if (!_hasReciprocal) {


### PR DESCRIPTION
I think this fixes the problem that I reported. The amount of overlap was stored in _overlapBases before checking if the overlap is above the threshold, breaking the one-to-one relationship with resultSet.
