### PR TITLE
[split]simple algorithm when n< FOPEN_MAX

### DIFF
--- a/src/split/splitBed.h
+++ b/src/split/splitBed.h
@@ -27,12 +27,13 @@ class BedSplit {
 private:
     std::string bedFileName;
     std::string outfileprefix;
-    unsigned int num_beans;
+    unsigned int num_chuncks;
     int bedType;
     std::vector<BED> items;
     
     void usage(std::ostream& out);
-    void saveBean(void* data,size_t file_index);
+    std::FILE* saveFileChunk(std::string& name,size_t file_index);
+    void saveBedItems(void* data,size_t file_index);
     void loadBed();
     int doSimpleSplit();
     int doEuristicSplitOnTotalSize();

--- a/test/split/test-split.sh
+++ b/test/split/test-split.sh
@@ -15,4 +15,11 @@ rm -f _tmp.*.bed
 ${BT} split -i tmp.bed -p _tmp -n 50 -a simple > _tmp.simple.tsv
 cat _tmp.simple.tsv
 
+echo "    slpit.simple...\c"
+rm -f _tmp.*.bed
+${BT} split -i tmp.bed -p _tmp -n 1000 -a simple > _tmp.simple.tsv
+cat _tmp.simple.tsv
+
+
+
 rm -f _tmp.*.bed jeter.bed tmp.bed  _tmp.simple.tsv  _tmp.size.tsv


### PR DESCRIPTION
As I said if  N< FOPEN_MAX, I now `fopen` all the N`FILE*`s, so there is no need to read the whole bed in memory.
I've also removed a dead code.

BTW Here is a nice example of piping with __GNU parallel__ (I used `wc` but one could imagine to `call samtools mpileup` for each BED... )

```
bedtools split -n 5 -p _tmp -a size -i test/intersect/sortAndNaming/bigTests/dbchr1.bed |\
cut -f 1 |  parallel wc -l '{}' 
7882 _tmp.00001.bed
7882 _tmp.00002.bed
7882 _tmp.00003.bed
7882 _tmp.00004.bed
7881 _tmp.00005.bed
```
