### PR TITLE
Fix a crash bug (when end == -1).

### DIFF
--- a/src/genomeCoverageBed/genomeCoverageBed.cpp
+++ b/src/genomeCoverageBed/genomeCoverageBed.cpp
@@ -124,7 +124,7 @@ void BedGenomeCoverage::AddCoverage(int start, int end) {
     // make sure the coordinates fit within the chrom
     if (start < _currChromSize)
         _currChromCoverage[start].starts++;
-    if (end < _currChromSize)
+    if (end >= 0 && end < _currChromSize)
         _currChromCoverage[end].ends++;
     else
         _currChromCoverage[_currChromSize-1].ends++;


### PR DESCRIPTION
We met a crash bug on following command:

    bedtools genomecov -ibam /path/to/foo.bam -bg > x.bg

It crashed when processing 'chr9_gl000199_random'.

With the help of gdb, the crash was located on src/genomeCoverageBed/genomeCoverageBed.cpp:99

    std::vector<DEPTH>().swap(_currChromCoverage);  // in BedGenomeCoverage::StartNewChrom

which indicated that there must have been memory access violation.

My best guess was at `BedGenomeCoverage::AddCoverage(int start, int end)`, and I tried to check `end` at runtime and found sometime it passed -1 value.

After the modification of this pull request, the problem should be solved.
