### PR TITLE
Minor warning and build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ $(UTIL_SUBDIRS) $(SUBDIRS): $(OBJ_DIR) $(BIN_DIR)
 clean:
 	@$(MAKE) --no-print-directory --directory=$(BT_ROOT) clean_api
 	@echo " * Cleaning up."
-	@rm -f $(OBJ_DIR)/* $(BIN_DIR)/*
+	@rm -f $(VERSION_FILE) $(OBJ_DIR)/* $(BIN_DIR)/*
 .PHONY: clean
 
 test: all

--- a/src/closestFile/closestMain.cpp
+++ b/src/closestFile/closestMain.cpp
@@ -5,10 +5,10 @@
  *      Author: nek3d
  */
 
-using namespace std;
-
 #include "closestFile.h"
 #include "ContextClosest.h"
+
+using namespace std;
 
 // define our program name
 #define PROGRAM_NAME "bedtools closest"

--- a/src/utils/FileRecordTools/Makefile
+++ b/src/utils/FileRecordTools/Makefile
@@ -28,7 +28,10 @@ _EXT_OBJECTS=SingleLineDelimTextFileReader.o BamFileReader.o Bed3Interval.o Bed6
 EXT_OBJECTS=$(patsubst %,$(OBJ_DIR)/%,$(_EXT_OBJECTS))
 BUILT_OBJECTS= $(patsubst %,$(OBJ_DIR)/%,$(OBJECTS))
 
-$(BUILT_OBJECTS): $(SOURCES) $(SUBDIRS)
+all: $(BUILT_OBJECTS) $(SUBDIRS)
+.PHONY: all
+
+$(BUILT_OBJECTS): $(SOURCES)
 	@echo "  * compiling FileRecordMgr.cpp"
 	@$(CXX) -c -o $(OBJ_DIR)/FileRecordMgr.o FileRecordMgr.cpp $(LDFLAGS) $(CXXFLAGS) $(INCLUDES)
 	@echo "  * compiling FileRecordMergeMgr.cpp"

--- a/src/utils/NewChromsweep/NewChromsweep.h
+++ b/src/utils/NewChromsweep/NewChromsweep.h
@@ -12,8 +12,6 @@
 #ifndef NEW_CHROMSWEEP_H
 #define NEW_CHROMSWEEP_H
 
-using namespace std;
-
 #include <string>
 #include "BTlist.h"
 #include "RecordKeyList.h"
@@ -23,6 +21,8 @@ using namespace std;
 #include <fstream>
 #include <stdlib.h>
 #include "QuickString.h"
+
+using namespace std;
 
 class Record;
 class FileRecordMgr;

--- a/src/utils/RecordOutputMgr/RecordOutputMgr.h
+++ b/src/utils/RecordOutputMgr/RecordOutputMgr.h
@@ -8,11 +8,11 @@
 #ifndef RECORDOUTPUTMGR_H_
 #define RECORDOUTPUTMGR_H_
 
-using namespace std;
-
 #include "ContextBase.h"
 #include "RecordKeyVector.h"
 #include "api/BamWriter.h"
+
+using namespace std;
 
 class BlockMgr;
 

--- a/src/utils/general/CommonHelp.cpp
+++ b/src/utils/general/CommonHelp.cpp
@@ -6,6 +6,8 @@
  */
 #include "CommonHelp.h"
 
+using namespace std;
+
 void CommonHelp() {
     cerr << "\t-iobuf\t"            << "Follow with desired integer size of read buffer." << endl;
     cerr << "\t\t" <<					"Optional suffixes K/M/G supported." << endl;

--- a/src/utils/general/CommonHelp.h
+++ b/src/utils/general/CommonHelp.h
@@ -8,8 +8,6 @@
 #ifndef COMMONHELPFILE_H_
 #define COMMONHELPFILE_H_
 
-using namespace std;
-
 #include <iostream>
 
 extern void CommonHelp();

--- a/src/utils/general/ParseTools.h
+++ b/src/utils/general/ParseTools.h
@@ -9,6 +9,7 @@
 #define PARSETOOLS_H_
 
 #include <cstring> //for memset
+#include <limits>
 #include <string>
 #include <vector>
 #include "QuickString.h"
@@ -37,13 +38,7 @@ int str2chrPos(const QuickString &str);
 template<class T>
 void int2str(int number, T& buffer, bool appendToBuf = false)
 {
-	int maxVal = (1 << 31) -1;
-	if (((int)(abs(number))) > maxVal) {
-		fprintf(stderr, "ERROR: number out of bounds.\n");
-		exit(1);
-	}
-	register int useNum = number;
-	if (useNum == 0) {
+	if (number == 0) {
 		if (appendToBuf) {
 			buffer.append("0");
 		} else {
@@ -52,42 +47,29 @@ void int2str(int number, T& buffer, bool appendToBuf = false)
 		return;
 	}
 	//check for negative numbers.
-	bool isNegative = useNum < 0;
+	bool isNegative = number < 0;
+	register unsigned useNum = number;
 	if (isNegative) {
 		useNum = 0 - useNum; //convert to positive.
 	}
 
-	//figure out how many digits we have
-	register int power = 10;
-	int numChars = 2 + (isNegative ? 1: 0);
-	while (power  <= useNum) {
-		power *= 10;
-		numChars++;
+	char tmpBuffer[numeric_limits<int>::digits10 + 3];
+	char *tmpBuf = &tmpBuffer[sizeof tmpBuffer];
+	*--tmpBuf = '\0';
+
+	while (useNum > 0) {
+		*--tmpBuf = (useNum % 10) + '0';
+		useNum /= 10;
 	}
 
-	char tmpBuf[numChars];
-	memset(tmpBuf, 0, numChars);
-
-	int bufIdx=0;
 	if (isNegative) {
-		tmpBuf[0] = '-';
-		bufIdx = 1;
+		*--tmpBuf = '-';
 	}
-	register int currDig=0;
 
-	power /= 10;
-	while (power) {
-
-		currDig = useNum / power;
-		useNum -= currDig * power;
-		tmpBuf[bufIdx] = currDig + 48; //48 is ascii for zero.
-		bufIdx++;
-		power /= 10;
-	}
 	if (!appendToBuf) {
 		buffer = tmpBuf;
 	} else {
-		buffer.append(tmpBuf, numChars-1);
+		buffer.append(tmpBuf);
 	}
 
 }


### PR DESCRIPTION
Another batch of mostly warning fixes, many of which pertain to small issues in header files and so are repeated over and over during a full build. 

* Fix `namespace std`-related Clang warnings
* Fix `int2str()` overflow warning by recoding using `unsigned` to fix overflow bugs
* Minor build fixes