### PR TITLE
README.md: Bump current version to 2.24.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 bedtools - a swiss army knife for genome arithmetic         
 ===================================================
 
-**Current version**: 2.23.0
+**Current version**: 2.24.0
 
 Note
 -------


### PR DESCRIPTION
In my experience explicit version numbers always get out of sync. Consider removing this line instead.