### PR TITLE
Check for non-empty vector

### DIFF
--- a/src/utils/bedFile/bedFile.cpp
+++ b/src/utils/bedFile/bedFile.cpp
@@ -158,7 +158,7 @@ void BedFile::GetLine(void) {
     getline(*_bedStream, _bedLine);
     
     // ditch \r for Windows.
-    if (_bedLine[_bedLine.size()-1] == '\r') {
+    if (_bedLine.size() && _bedLine[_bedLine.size()-1] == '\r') {
         _bedLine.resize(_bedLine.size()-1);
     }
     // increment the line number


### PR DESCRIPTION
This came up on my Valgrind log while using the API.