### PR TITLE
Fix issue 327: Changed expected output for merge.t11 to reflect the current output of merge

### DIFF
--- a/test/merge/test-merge.sh
+++ b/test/merge/test-merge.sh
@@ -145,9 +145,10 @@ rm obs exp
 ###########################################################
 #  Test that stranded merge not allowed with VCF
 ###########################################################
+VCF_FILE=testA.vcf
 echo "    merge.t11...\c"
-echo "***** ERROR: stranded merge not supported for VCF files. *****" >exp
-$BT merge -i testA.vcf -s 2>&1 > /dev/null | head -2 | tail -1 > obs
+echo "***** ERROR: stranded merge not supported for VCF file $VCF_FILE. *****" >exp
+$BT merge -i $VCF_FILE -s 2>&1 > /dev/null | head -2 | tail -1 > obs
 check exp obs
 rm obs exp
 


### PR DESCRIPTION
I think this patch resolves issue #327. The expected output for the test has been changed to reflect the actual error log printed by `merge`.