### PR TITLE
Fix complement segfault for empty input intervals.

### DIFF
--- a/src/complementFile/complementFile.cpp
+++ b/src/complementFile/complementFile.cpp
@@ -59,7 +59,7 @@ void ComplementFile::processHits(RecordOutputMgr *outputMgr, RecordKeyVector &hi
 	if (rec->getStartPos() != 0)
 	{
 		int endPos = rec->getStartPos();
-		printRecord(endPos);		
+		printRecord(endPos);
 	}
 	_currStartPos = rec->getEndPos();
 }
@@ -69,10 +69,10 @@ void ComplementFile::cleanupHits(RecordKeyVector &hits)
 	_frm->deleteMergedRecord(hits);
 }
 
-bool ComplementFile::finalizeCalculations() {
+void ComplementFile::giveFinalReport(RecordOutputMgr *outputMgr) {
+  _outputMgr = outputMgr;
 	outPutLastRecordInPrevChrom();
 	fastForward("");
-	return true;
 }
 
 void ComplementFile::outPutLastRecordInPrevChrom()
@@ -128,5 +128,3 @@ void ComplementFile::printRecord(int endPos)
 	_outputMgr->newline();
 
 }
-
-

--- a/src/complementFile/complementFile.h
+++ b/src/complementFile/complementFile.h
@@ -26,8 +26,8 @@ public:
 	virtual bool findNext(RecordKeyVector &hits);
 	virtual void processHits(RecordOutputMgr *outputMgr, RecordKeyVector &hits);
 	virtual void cleanupHits(RecordKeyVector &hits);
-	virtual bool finalizeCalculations();
-	virtual void  giveFinalReport(RecordOutputMgr *outputMgr) {}
+	virtual bool finalizeCalculations() {return true;}
+	virtual void giveFinalReport(RecordOutputMgr *outputMgr);
 
 
 protected:


### PR DESCRIPTION
`_outputMgr` is not assigned by driver for an empty file.