### PR TITLE
Prevent trivial Intel warnings

### DIFF
--- a/src/regressTest/RegressTest.cpp
+++ b/src/regressTest/RegressTest.cpp
@@ -169,7 +169,7 @@ void RegressTest::echoOptions() const
 
 	for (int i=0; i < 2; i++) {
 		fileListType *fileList = i == 0 ?  _correctFiles : _performFiles;
-		fprintf(_fpReportFile, "\n\n\%s TEST FILES:\n", i ==0 ? "CORRECTNESS" : "PERFORMANCE");
+		fprintf(_fpReportFile, "\n\n%s TEST FILES:\n", i ==0 ? "CORRECTNESS" : "PERFORMANCE");
 		for (fileListType::const_iterator iter = fileList->begin(); iter != fileList->end(); iter++) {
 
 			const string &filename = iter->first;

--- a/src/sampleFile/sampleFile.cpp
+++ b/src/sampleFile/sampleFile.cpp
@@ -1,6 +1,6 @@
 #include "sampleFile.h"
 
-static const bool SampleRecordLtFn(const Record *rec1, const Record *rec2) {
+static bool SampleRecordLtFn(const Record *rec1, const Record *rec2) {
 	return (*rec1 < *rec2);
 }
 

--- a/src/utils/FileRecordTools/Records/RecordKeyList.cpp
+++ b/src/utils/FileRecordTools/Records/RecordKeyList.cpp
@@ -26,16 +26,16 @@ const RecordKeyList &RecordKeyList::operator=(const RecordKeyList &other)
 	return *this;
 }
 
-const RecordKeyList::const_iterator_type RecordKeyList::begin()  {
+RecordKeyList::const_iterator_type RecordKeyList::begin()  {
 	return _list.begin();
 }
 
-const RecordKeyList::const_iterator_type RecordKeyList::next()  {
+RecordKeyList::const_iterator_type RecordKeyList::next()  {
 	return _list.next();
 }
 
 
-const RecordKeyList::const_iterator_type RecordKeyList::end() {
+RecordKeyList::const_iterator_type RecordKeyList::end() {
 	return _list.end();
 }
 

--- a/src/utils/FileRecordTools/Records/RecordKeyList.h
+++ b/src/utils/FileRecordTools/Records/RecordKeyList.h
@@ -22,9 +22,9 @@ public:
     ~RecordKeyList();
 
     const RecordKeyList &operator=(const RecordKeyList &other);
-    const const_iterator_type begin();
-    const const_iterator_type next();
-    const const_iterator_type end();
+    const_iterator_type begin();
+    const_iterator_type next();
+    const_iterator_type end();
     size_t size() const ;
     bool empty() const ; //only checks whether list is empty. Doesn't check key.
     void push_back(elemType item);

--- a/src/utils/FileRecordTools/Records/RecordKeyVector.cpp
+++ b/src/utils/FileRecordTools/Records/RecordKeyVector.cpp
@@ -48,18 +48,18 @@ const RecordKeyVector &RecordKeyVector::operator=(const RecordKeyVector &other)
 	return *this;
 }
 
-const RecordKeyVector::const_iterator_type RecordKeyVector::begin()  {
+RecordKeyVector::const_iterator_type RecordKeyVector::begin()  {
 	_currPos = 0;
 	return _recVec->begin();
 }
 
-const RecordKeyVector::const_iterator_type RecordKeyVector::next()  {
+RecordKeyVector::const_iterator_type RecordKeyVector::next()  {
 	_currPos++;
 	return _recVec->begin() + _currPos;
 }
 
 
-const RecordKeyVector::const_iterator_type RecordKeyVector::end() {
+RecordKeyVector::const_iterator_type RecordKeyVector::end() {
 	return _recVec->end();
 }
 

--- a/src/utils/FileRecordTools/Records/RecordKeyVector.h
+++ b/src/utils/FileRecordTools/Records/RecordKeyVector.h
@@ -26,9 +26,9 @@ public:
     ~RecordKeyVector();
 
     const RecordKeyVector &operator=(const RecordKeyVector &other);
-    const const_iterator_type begin();
-    const const_iterator_type next();
-    const const_iterator_type end();
+    const_iterator_type begin();
+    const_iterator_type next();
+    const_iterator_type end();
     size_t size() const ;
     bool empty() const ; //only checks whether list is empty. Doesn't check key.
     void push_back(elemType item);


### PR DESCRIPTION
A few tiny changes that prevent warnings from Intel's `icpc` compiler.  Motivated by [this seqanswers thread](http://seqanswers.com/forums/showthread.php?t=66910).
