### PR TITLE
Added tip for extracting single region BED files using getfasta

### DIFF
--- a/docs/content/tools/getfasta.rst
+++ b/docs/content/tools/getfasta.rst
@@ -21,6 +21,9 @@ intervals defined in a BED/GFF/VCF file.
     2. You can use the UNIX ``fold`` command to set the line width of the 
     FASTA output.  For example, ``fold -w 60`` will make each line of the FASTA
     file have at most 60 nucleotides for easy viewing.
+    
+    3. BED files containing a single region require a newline character at the end of
+    the line, otherwise a blank output file is produced.
 
 .. seealso::
 


### PR DESCRIPTION
Added tip for using single region BED files for fasta extraction using getfasta.

Currently if a single region BED file is provided without a newline character at the end of the region a blank output file is created without explanation of the error.