### PR TITLE
Fix BedFile::GetNextBed()'s handling of missing newlines

### DIFF
--- a/src/utils/bedFile/bedFile.h
+++ b/src/utils/bedFile/bedFile.h
@@ -404,9 +404,6 @@ public:
     // dump the header, which is collected as part of Open()
     void PrintHeader(void);
 
-    // get the next line in the file. splits a line in _bedFields
-    void GetLine(void);
-
     // Get the next BED entry in an opened BED file.
     bool GetNextBed (BED &bed, bool forceSorted = false);
     


### PR DESCRIPTION
This fixes the underlying _single region BED file is provided without a newline character_ problem in PR #403, so might be an alternative to adding the suggested tip.  I guess the problem exists everywhere one-line BED files might be used, so making the reader a little bit more resilient everywhere might be good.

----

A BED file with one record without a terminating newline character would not be returned as valid by GetNextBed(), because good() could not allow for the valid line already read by GetHeader() and stored in _bedLine.

Check the return value from getline() rather than checking good(). This is in general more robust than checking good() etc before reading.