### PR TITLE
Added feature: name, chromosome and position in fasta headers #406

### DIFF
--- a/src/fastaFromBed/fastaFromBed.cpp
+++ b/src/fastaFromBed/fastaFromBed.cpp
@@ -104,9 +104,32 @@ void Bed2Fa::ReportDNA(const BED &bed, string &dna) {
         }
         else {
             if (_useFasta == true)
-                *_faOut  << ">" << bed.name << endl << dna << endl;
+                if(_useStrand == true)
+        		{
+				*_faOut << ">" << bed.name << "::" << bed.chrom << ":" 
+                        << bed.start << "-" << bed.end   
+                        << "(" << bed.strand << ")" << endl << dna << endl;
+            	}
+            	else
+            	{
+            	*_faOut << ">" << bed.name << "::" << bed.chrom << ":" 
+                        << bed.start << "-" << bed.end   
+                        << endl << dna << endl;
+            	}
             else
-                *_faOut  << bed.name << "\t" << dna << endl;
+            	if(_useStrand == true)
+        		{
+					*_faOut << bed.name << "::" << bed.chrom << ":" 
+                        << bed.start << "-" << bed.end   
+                        << "(" << bed.strand << ")" << "\t" << dna << endl;
+            	}
+            	else
+            	{
+            		*_faOut << bed.name << "::" << bed.chrom << ":" 
+                        << bed.start << "-" << bed.end   
+                        << "\t" << dna << endl;
+            	}
+                
         }
     }
 }


### PR DESCRIPTION
I have added the feature as requested in #406. The name switch in getfasta till now only printed the name field. Now it prints the name field in bed file entry along with the chromosome name, start and end position along with the strand if strandedness is imposed.