### PR TITLE
Set CXX only if not pre-defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ export OBJ_DIR	= obj
 export BIN_DIR	= bin
 export SRC_DIR	= src
 export UTIL_DIR	= src/utils
-export CXX		= g++
+export CXX	?= g++
 ifeq ($(DEBUG),1)
 export CXXFLAGS = -Wall -O0 -g -fno-inline -fkeep-inline-functions -D_FILE_OFFSET_BITS=64 -fPIC -DDEBUG -D_DEBUG
 else


### PR DESCRIPTION
Allow a user to specify the compiler externally. This is useful if downstream wants to build a set of packages with a specific compiler through a build framework. Also useful for contributors that want to compile-test with e.g. clang, xlC, icpc, etc.
