### PR TITLE
Improve user experience for "multicov: Could not open input BAM files."

### DIFF
--- a/src/multiBamCov/multiBamCov.cpp
+++ b/src/multiBamCov/multiBamCov.cpp
@@ -110,6 +110,7 @@ void MultiCovBam::CollectCoverage()
     if ( !reader.Open(_bam_files) )
     {
         cerr << "Could not open input BAM files." << endl;
+        cerr << reader.GetErrorString() << endl;
         exit(1);
     }
     else
@@ -207,7 +208,8 @@ void MultiCovBam::CollectCoverage()
             _bed->Close();
         }
         else {
-            cerr << "Could not find indexes." << endl;
+            cerr << "Could not find/load indexes." << endl;
+            cerr << reader.GetErrorString() << endl;
             reader.Close();
             exit(1);
         }

--- a/src/utils/BamTools/src/api/internal/bam/BamMultiReader_p.cpp
+++ b/src/utils/BamTools/src/api/internal/bam/BamMultiReader_p.cpp
@@ -762,8 +762,8 @@ bool BamMultiReaderPrivate::ValidateReaders(void) const {
                  (firstRef.RefLength != currentRef.RefLength) )
             {
                 stringstream s("");
-                s << "mismatched references found in" << reader->GetFilename()
-                  << "expected: " << endl;
+                s << "mismatched references found in " << reader->GetFilename()
+                  << " expected: " << endl;
 
                 // print first reader's reference data
                 RefVector::const_iterator refIter = firstReaderRefData.begin();


### PR DESCRIPTION
Improve user experience for "multicov: Could not open input BAM files." by propagating the error messages from BamMultiReaderPrivate::Open to the users.

See issue: https://github.com/arq5x/bedtools2/issues/52