### PR TITLE
Bugfix bedtools closest: Do not segfault when b file is empty.

### DIFF
--- a/src/utils/RecordOutputMgr/RecordOutputMgr.cpp
+++ b/src/utils/RecordOutputMgr/RecordOutputMgr.cpp
@@ -510,8 +510,10 @@ void RecordOutputMgr::null(bool queryType, bool dbType)
 	default:
 		break;
 	}
-	dummyRecord->printNull(_outBuf);
-	delete dummyRecord;
+	if (dummyRecord) {
+		dummyRecord->printNull(_outBuf);
+		delete dummyRecord;
+	}
 }
 
 void RecordOutputMgr::printKey(const Record *key, const string & start, const string & end)


### PR DESCRIPTION
Only try to print a null record when the record type is known.
In case of an empty b file, the record type can not be determined.

This fixes "Segmentation fault with closestBed":
  https://github.com/arq5x/bedtools2/issues/486