### PR TITLE
Fix output of freqasc, freqdesc, distinct_sort_num and distinct_sort_…

### DIFF
--- a/src/utils/KeyListOps/KeyListOpsMethods.cpp
+++ b/src/utils/KeyListOps/KeyListOpsMethods.cpp
@@ -225,7 +225,7 @@ const string &KeyListOpsMethods::getDistinctSortNum(bool asc) {
 	_retStr.clear();
 	ostringstream s;
 	for (vector<double>::iterator iter = _numArray.begin(); iter != endIter; iter++) {
-		if (iter != _numArray.begin()) _retStr += _delimStr;
+		if (iter != _numArray.begin()) s << _delimStr;
 		s << *iter;
 	}
 	_retStr.append(s.str());
@@ -286,7 +286,7 @@ const string &KeyListOpsMethods::getFreqDesc() {
 	_retStr.clear();
 	ostringstream s;
 	for (histDescType::iterator histIter = hist.begin(); histIter != hist.end(); histIter++) {
-		if (histIter != hist.begin()) _retStr += _delimStr;
+		if (histIter != hist.begin()) s << _delimStr;
 		s << histIter->second;
 		s << ":";
 		s << histIter->first;
@@ -310,7 +310,7 @@ const string &KeyListOpsMethods::getFreqAsc() {
 	_retStr.clear();
 	ostringstream s;
 	for (histAscType::iterator histIter = hist.begin(); histIter != hist.end(); histIter++) {
-		if (histIter != hist.begin()) _retStr += _delimStr;
+		if (histIter != hist.begin()) s << _delimStr;
 		s << histIter->second;
 		s << ":";
 		s << histIter->first;


### PR DESCRIPTION
…num_desc operations.

Put delimiter after each element for freqasc, freqdesc,
distinct_sort_num and distinct_sort_num_desc operations
of bedtools groupby and bedtools map.

This fixes https://github.com/arq5x/bedtools2/issues/490:
  groupby -o freqdesc does not put delimiters between value:freq pairs