### PR TITLE
Fix file detection when switching a and b order

### DIFF
--- a/src/utils/Contexts/ContextBase.cpp
+++ b/src/utils/Contexts/ContextBase.cpp
@@ -135,7 +135,8 @@ bool ContextBase::determineOutputType() {
 	}
 
 	//Otherwise, if the input is BAM, then the output is BAM
-	if (getFile(0)->getFileType() == FileRecordTypeChecker::BAM_FILE_TYPE) {
+	int fileIdx = hasIntersectMethods() ? _queryFileIdx : 0;
+	if (_files[fileIdx]->getFileType() == FileRecordTypeChecker::BAM_FILE_TYPE) {
 		setOutputFileType(FileRecordTypeChecker::BAM_FILE_TYPE);
 		return true;
 	}

--- a/src/utils/Contexts/ContextIntersect.cpp
+++ b/src/utils/Contexts/ContextIntersect.cpp
@@ -212,16 +212,7 @@ bool ContextIntersect::determineOutputType() {
 			_maxNumDatabaseFields = numFields;
 		}
 	}
-
-	//If the query is BAM, and bed output wasn't specified, then the output is BAM.
-	if (getQueryFileType() == FileRecordTypeChecker::BAM_FILE_TYPE && !getExplicitBedOutput()) {
-		setOutputFileType(FileRecordTypeChecker::BAM_FILE_TYPE);
-		_outputTypeDetermined = true;
-		return true;
-
-	}
 	return ContextBase::determineOutputType();
-
 }
 
 bool ContextIntersect::handle_a()


### PR DESCRIPTION
Fix setting of correct output type if -a is given after -b argment.

Set the correct output type based on the file given by -a, -abam or -i.

Before this patch, the output type was determined on the first
file. If -b was specified before -a, the first -b file would
be used instead of the -a file.

This fixes the first problem of issue #497:
  "Switching order of -a and -b paramter in bedtools intersect when -b file is BAM file, outputs BAM header."