### PR TITLE
minor:  Fixed the same typo/misspelling in three locations.

### DIFF
--- a/src/utils/NewChromsweep/NewChromsweep.cpp
+++ b/src/utils/NewChromsweep/NewChromsweep.cpp
@@ -359,7 +359,7 @@ void NewChromSweep::testChromOrder(const Record *rec)
             // ERROR.
             fprintf(stderr, "ERROR: Sort order was unspecified, and file %s is not sorted lexicographically.\n",
                     _context->getInputFileName(fileIdx).c_str());
-            fprintf(stderr, "       Please re-reun with the -g option for a genome file.\n       See documentation for details.\n");
+            fprintf(stderr, "       Please rerun with the -g option for a genome file.\n       See documentation for details.\n");
             exit(1);
         }
         _lexicoDisproven = true;

--- a/test/closest/sortAndNaming/test-sort-and-naming.sh
+++ b/test/closest/sortAndNaming/test-sort-and-naming.sh
@@ -302,7 +302,7 @@ rm exp obs
 echo -e "    closest.22...\c"
 echo \
 "ERROR: Sort order was unspecified, and file num_all.bed is not sorted lexicographically.
-       Please re-reun with the -g option for a genome file.
+       Please rerun with the -g option for a genome file.
        See documentation for details." > exp
 $BT closest -a num_missing.bed -b num_all.bed 2>&1 > /dev/null | cat - > obs
 check exp obs

--- a/test/intersect/sortAndNaming/test-sort-and-naming.sh
+++ b/test/intersect/sortAndNaming/test-sort-and-naming.sh
@@ -38,7 +38,7 @@ rm obs
 echo -e "    intersect.t02...\c"
 echo \
 "ERROR: Sort order was unspecified, and file q1a_num.bed is not sorted lexicographically.
-       Please re-reun with the -g option for a genome file.
+       Please rerun with the -g option for a genome file.
        See documentation for details." > exp
 $BT intersect -a q1a_num.bed -b db1_num.bed db2_numBackwards.bed -sorted 2>&1 > /dev/null | cat - > obs
 check obs exp


### PR DESCRIPTION
Changed 're-reun' to 'rerun' in three error messages.  