### PR TITLE
Add "-fullHeader" support to "bedtools maskfasta".

### DIFF
--- a/src/maskFastaFromBed/Makefile
+++ b/src/maskFastaFromBed/Makefile
@@ -10,6 +10,7 @@ INCLUDES = -I$(UTILITIES_DIR)/bedFile/ \
            -I$(UTILITIES_DIR)/lineFileUtilities/ \
            -I$(UTILITIES_DIR)/gzstream/ \
            -I$(UTILITIES_DIR)/fileType/ \
+           -I$(UTILITIES_DIR)/Fasta/ \
            -I$(UTILITIES_DIR)/version/
 
 # ----------------------------------

--- a/src/maskFastaFromBed/maskFastaFromBed.cpp
+++ b/src/maskFastaFromBed/maskFastaFromBed.cpp
@@ -13,14 +13,16 @@
 #include "maskFastaFromBed.h"
 
 
-MaskFastaFromBed::MaskFastaFromBed(const string &fastaInFile,  const string &bedFile, 
-                                   const string &fastaOutFile, bool softMask, char maskChar) {
-    _softMask     = softMask;
-    _fastaInFile  = fastaInFile;
-    _bedFile      = bedFile;
-    _fastaOutFile = fastaOutFile;
-    _maskChar     = maskChar;
-    _bed          = new BedFile(_bedFile);
+MaskFastaFromBed::MaskFastaFromBed(const string &fastaInFile,  const string &bedFile,
+                                   const string &fastaOutFile, bool softMask, char maskChar,
+                                   bool useFullHeader) {
+    _softMask      = softMask;
+    _fastaInFile   = fastaInFile;
+    _bedFile       = bedFile;
+    _fastaOutFile  = fastaOutFile;
+    _maskChar      = maskChar;
+    _useFullHeader = useFullHeader;
+    _bed           = new BedFile(_bedFile);
 
     _bed->loadBedFileIntoMapNoBin();
     // start masking.
@@ -56,6 +58,7 @@ void MaskFastaFromBed::MaskFasta() {
 
     /* Read the fastaDb chromosome by chromosome*/
     string fastaInLine;
+    string currChromFull;
     string currChrom;
     string currDNA = "";
     currDNA.reserve(500000000);
@@ -103,11 +106,12 @@ void MaskFastaFromBed::MaskFasta() {
                     }
                 }
                 // write the masked chrom to the output file
-                PrettyPrintChrom(faOut, currChrom, currDNA, fastaWidth);
+                PrettyPrintChrom(faOut, _useFullHeader ? currChromFull : currChrom, currDNA, fastaWidth);
             }
 
             // reset for the next chromosome.
-            currChrom = fastaInLine.substr(1, fastaInLine.find_first_of(" ")-1);
+            currChromFull = fastaInLine.substr(1);
+            currChrom = split(currChromFull, " \t").at(0);
             currDNA = "";
         }
     }
@@ -133,7 +137,7 @@ void MaskFastaFromBed::MaskFasta() {
                 currDNA.replace(start, length, hardmask);
             }
         }
-        PrettyPrintChrom(faOut, currChrom, currDNA, fastaWidth);
+        PrettyPrintChrom(faOut, _useFullHeader ? currChromFull : currChrom, currDNA, fastaWidth);
     }
 
     // closed for business.

--- a/src/maskFastaFromBed/maskFastaFromBed.h
+++ b/src/maskFastaFromBed/maskFastaFromBed.h
@@ -13,6 +13,7 @@
 
 #include "bedFile.h"
 #include "sequenceUtils.h"
+#include "split.h"
 #include <vector>
 #include <iostream>
 #include <fstream>
@@ -28,8 +29,9 @@ class MaskFastaFromBed {
 public:
 
     // constructor
-    MaskFastaFromBed(const string &fastaInFile,  const string &bedFile, 
-                     const string &fastaOutFile, bool softMask, char maskChar);
+    MaskFastaFromBed(const string &fastaInFile,  const string &bedFile,
+                     const string &fastaOutFile, bool softMask, char maskChar,
+                     bool useFullHeader);
 
     // destructor
     ~MaskFastaFromBed(void);
@@ -38,6 +40,7 @@ public:
 private:
 
     bool _softMask;
+    bool _useFullHeader;
 
     string _fastaInFile;
     string _bedFile;

--- a/src/maskFastaFromBed/maskFastaFromBedMain.cpp
+++ b/src/maskFastaFromBed/maskFastaFromBedMain.cpp
@@ -37,11 +37,12 @@ int maskfastafrombed_main(int argc, char* argv[]) {
     string fastaOutFile;
 
     // defaults for parameters
-    bool haveFastaIn  = false;
-    bool haveBed      = false;
-    bool haveFastaOut = false;
-    bool softMask     = false;
-    char maskChar     = 'N';
+    bool haveFastaIn   = false;
+    bool haveBed       = false;
+    bool haveFastaOut  = false;
+    bool softMask      = false;
+    char maskChar      = 'N';
+    bool useFullHeader = false;
 
     // check to see if we should print out some help
     if(argc <= 1) showHelp = true;
@@ -99,6 +100,9 @@ int maskfastafrombed_main(int argc, char* argv[]) {
                 i++;
             }
         }
+        else if(PARAMETER_CHECK("-fullHeader", 11, parameterLength)) {
+            useFullHeader = true;
+        }
         else {
             cerr << "*****ERROR: Unrecognized parameter: " << argv[i] << " *****" << endl << endl;
             showHelp = true;
@@ -111,7 +115,7 @@ int maskfastafrombed_main(int argc, char* argv[]) {
 
     if (!showHelp) {
 
-        MaskFastaFromBed *maskFasta = new MaskFastaFromBed(fastaInFile, bedFile, fastaOutFile, softMask, maskChar);
+        MaskFastaFromBed *maskFasta = new MaskFastaFromBed(fastaInFile, bedFile, fastaOutFile, softMask, maskChar, useFullHeader);
         delete maskFasta;
     }
     else {
@@ -129,13 +133,16 @@ void maskfastafrombed_help(void) {
     cerr << "Usage:   " << PROGRAM_NAME << " [OPTIONS] -fi <fasta> -fo <fasta> -bed <bed/gff/vcf>" << endl << endl;
 
     cerr << "Options:" << endl;
-    cerr << "\t-fi\tInput FASTA file" << endl;
-    cerr << "\t-bed\tBED/GFF/VCF file of ranges to mask in -fi" << endl;
-    cerr << "\t-fo\tOutput FASTA file" << endl;
-    cerr << "\t-soft\tEnforce \"soft\" masking.  That is, instead of masking with Ns," << endl;
-    cerr << "\t\tmask with lower-case bases." << endl;
-    cerr << "\t-mc\tReplace masking character.  That is, instead of masking" << endl;
-    cerr << "\t\twith Ns, use another character." << endl << endl;
+    cerr << "\t-fi\t\tInput FASTA file" << endl;
+    cerr << "\t-bed\t\tBED/GFF/VCF file of ranges to mask in -fi" << endl;
+    cerr << "\t-fo\t\tOutput FASTA file" << endl;
+    cerr << "\t-soft\t\tEnforce \"soft\" masking." << endl;
+    cerr << "\t\t\tMask with lower-case bases, instead of masking with Ns." << endl;
+    cerr << "\t-mc\t\tReplace masking character." << endl;
+    cerr << "\t\t\tUse another character, instead of masking with Ns." << endl;
+    cerr << "\t-fullHeader\tUse full fasta header." << endl;
+    cerr << "\t\t\tBy default, only the word before the first space or tab" << endl;
+    cerr << "\t\t\tis used." << endl << endl;
     // end the program here
     exit(1);
 


### PR DESCRIPTION
Add "-fullHeader" support to "bedtools maskfasta" so it prints
the full FASTA sequence name in the output FASTA file instead
of only the part before the space of TAB.

"-fullHeader" argument is also used by:
  - bedtools getfasta
  - bedtools nuc
for the same reason.

This fixes issue https://github.com/arq5x/bedtools2/issues/504:
  "maskFastaFromBed discards additional annotation from FASTA header line"