### PR TITLE
Resolve issue #538 and remove unnecessary namespace import

### DIFF
--- a/src/utils/FileRecordTools/FileRecordMgr.h
+++ b/src/utils/FileRecordTools/FileRecordMgr.h
@@ -123,7 +123,7 @@ protected:
 	bool _useFullBamTags;
 
 	//members for enforcing sorted order.
-	set<string> _foundChroms;
+        std::set<string> _foundChroms;
 	string _prevChrom;
 	int _prevStart;
 	int _prevChromId;

--- a/src/utils/FileRecordTools/FileRecordMgr.h
+++ b/src/utils/FileRecordTools/FileRecordMgr.h
@@ -25,8 +25,6 @@
 #include "RecordKeyVector.h"
 #include "BlockMgr.h"
 
-using namespace std;
-
 class Record;
 class NewGenomeFile;
 


### PR DESCRIPTION
- Resolves issue #538, making an implicit `std::` qualifier on a [`set` declaration](https://github.com/arq5x/bedtools2/blob/master/src/utils/FileRecordTools/FileRecordMgr.h#L126) explicit.
- Removes an unnecessary [`std` namespace import](https://github.com/arq5x/bedtools2/blob/master/src/utils/FileRecordTools/FileRecordMgr.h#L28) within [`FileRecordMgr.h`](https://github.com/arq5x/bedtools2/blob/master/src/utils/FileRecordTools/FileRecordMgr.h).