### PR TITLE
Ignore CR characters at the ends of lines

### DIFF
--- a/src/utils/FileRecordTools/FileReaders/BufferedStreamMgr.cpp
+++ b/src/utils/FileRecordTools/FileReaders/BufferedStreamMgr.cpp
@@ -125,7 +125,7 @@ bool BufferedStreamMgr::getLine(string &line)
 	//strip any whitespace characters, such as DOS newline characters or extra tabs,
 	//from the end of the line
 	int lastPos = line.size();
-	while (line[lastPos-1] == '\n') lastPos--;
+	while (lastPos > 0 && (line[lastPos-1] == '\n' || line[lastPos-1] == '\r')) lastPos--;
 	line.resize(lastPos);
 
 	return retVal;

--- a/src/utils/fileType/FileRecordTypeChecker.cpp
+++ b/src/utils/fileType/FileRecordTypeChecker.cpp
@@ -183,6 +183,11 @@ bool FileRecordTypeChecker::handleTextFormat(const char *buffer, size_t len)
 
 		string line(_tokenizer.getElem(_firstValidDataLineIdx));
 
+		// ditch \r for Windows if necessary.
+		if (line.size() && line[line.size()-1] == '\r') {
+			line.resize(line.size()-1);
+		}
+
 		_tokenizer.setKeepFinalIncompleteElem(Tokenizer::USE_NOW);
 		_tokenizer.setNumExpectedItems(_numFields);
 		_tokenizer.tokenize(line, _delimChar);


### PR DESCRIPTION
The older code in _bedFile.cpp_ and similar strips trailing CR characters so that (on Unix) bedtools can work on DOS-style or Unix-style files with CR-LF or LF line terminators.  Somewhere along the line, this feature seems to have disappeared.

We recently had a mysterious error with a 3-column BED file downloaded from Ensembl:

```
$ bedtools merge -I foo.bed
ERROR: file foo.bed has non positional records, which are only valid for 
 the groupBy tool. Perhaps you are using a header line(s) that starts with 
 something other than "#", "chrom", or "chr" (any case)?
```

This turned out to be because the file had CR-LF line terminators and was not being recognised as BED (as the third column contained non-digit characters — namely the CR!), but this took a long time to figure out.

I seem to recall that bedtools has in the past treated Unix and DOS line terminators interchangeably.  This suggested patch restores that functionality for code using _BufferedStreamMgr.cpp_.