### PR TITLE
Various warning fixes

### DIFF
--- a/src/utils/BamTools/src/api/BamConstants.h
+++ b/src/utils/BamTools/src/api/BamConstants.h
@@ -125,11 +125,11 @@ const char BAM_DNA_DEL   = '-';
 const char BAM_DNA_PAD   = '*';
 
 // zlib & BGZF constants
-const char GZIP_ID1   = 31;
-const char GZIP_ID2   = 139;
+const char GZIP_ID1   = '\x1F';
+const char GZIP_ID2   = '\x8B';
 const char CM_DEFLATE = 8;
 const char FLG_FEXTRA = 4;
-const char OS_UNKNOWN = 255;
+const char OS_UNKNOWN = '\xFF';
 const char BGZF_XLEN  = 6;
 const char BGZF_ID1   = 66;
 const char BGZF_ID2   = 67;

--- a/src/utils/BamTools/src/api/internal/io/HostAddress_p.cpp
+++ b/src/utils/BamTools/src/api/internal/io/HostAddress_p.cpp
@@ -263,7 +263,7 @@ bool HostAddress::operator<(const HostAddress& other) const {
     // if self is IPv4
     if ( m_protocol == HostAddress::IPv4Protocol ) {
         if ( other.m_protocol == HostAddress::IPv4Protocol )
-            return m_ip4Address < m_ip4Address;
+            return m_ip4Address < other.m_ip4Address;
     }
 
     // if self is IPv6

--- a/src/utils/Contexts/ContextBase.cpp
+++ b/src/utils/Contexts/ContextBase.cpp
@@ -13,7 +13,6 @@
 ContextBase::ContextBase()
 :
   _program(UNSPECIFIED_PROGRAM),
-  _files(NULL),
   _allFilesOpened(false),
   _genomeFile(NULL),
   _outputFileType(FileRecordTypeChecker::UNKNOWN_FILE_TYPE),


### PR DESCRIPTION
Hello Aaron,

Some trivial fixes that silence warnings with current (Mac OS Sierra) Clang.  (One of which also silences a warning with GCC 6.3.)  Mostly in bamtools, including one fix ported from bamtools 2.4 and one that remains in current presumably-unmaintained bamtools, alas.