### PR TITLE
strandqueue: de-const for stricter Xcode 9 rules

### DIFF
--- a/src/utils/FileRecordTools/Records/StrandQueue.cpp
+++ b/src/utils/FileRecordTools/Records/StrandQueue.cpp
@@ -25,11 +25,11 @@ StrandQueue::~StrandQueue() {
 	}
 }
 
-Record *StrandQueue::top() const
+Record *StrandQueue::top()
 {
 	int minIdx = getMinIdx();
 	if (minIdx == -1) return NULL;
-	return const_cast<Record *>(_queues[minIdx]->top());
+	return _queues[minIdx]->top();
 }
 
 void StrandQueue::pop() {
@@ -38,8 +38,8 @@ void StrandQueue::pop() {
 	_queues[minIdx]->pop();
 }
 
-Record * StrandQueue::top(Record::strandType strand) const {
-	const Record *record = NULL;
+Record * StrandQueue::top(Record::strandType strand) {
+	Record *record = NULL;
 	switch (strand) {
 	case Record::FORWARD:
 		if (_queues[0]->empty()) return NULL;
@@ -57,10 +57,10 @@ Record * StrandQueue::top(Record::strandType strand) const {
 	default:
 		break;
 	}
-	return const_cast<Record *>(record);
+	return record;
 }
 
-void StrandQueue::pop(Record::strandType strand) const {
+void StrandQueue::pop(Record::strandType strand) {
 	switch (strand) {
 	case Record::FORWARD:
 		if (_queues[0]->empty()) return;
@@ -95,7 +95,7 @@ void StrandQueue::push(Record *record) {
 	}
 }
 
-size_t StrandQueue::size() const {
+size_t StrandQueue::size() {
 	size_t sumSize = 0;
 	for (int i = 0; i < NUM_QUEUES; i++) {
 		sumSize += _queues[i]->size();
@@ -103,7 +103,7 @@ size_t StrandQueue::size() const {
 	return sumSize;
 }
 
-bool StrandQueue::empty() const {
+bool StrandQueue::empty() {
 	for (int i = 0; i < NUM_QUEUES; i++) {
 		if (!_queues[i]->empty()) {
 			return false;
@@ -113,7 +113,7 @@ bool StrandQueue::empty() const {
 }
 
 
-int StrandQueue::getMinIdx() const {
+int StrandQueue::getMinIdx() {
 	if (empty()) return -1;
 	const Record *minRec = NULL;
 	int minIdx = -1;

--- a/src/utils/FileRecordTools/Records/StrandQueue.h
+++ b/src/utils/FileRecordTools/Records/StrandQueue.h
@@ -20,17 +20,17 @@ public:
 	StrandQueue();
 	~StrandQueue();
 
-	Record * top() const;
+	Record * top();
 	void pop();
-	Record * top(Record::strandType strand) const;
-	void pop(Record::strandType strand) const;
+	Record * top(Record::strandType strand);
+	void pop(Record::strandType strand);
 	void push(Record *record);
-	size_t size() const;
-	bool empty() const;
+	size_t size();
+	bool empty();
 
 private:
 //	static RecordPtrSortFunctor _recSortFunctor;
-	typedef priority_queue<Record *, vector<const Record *>, RecordPtrSortDescFunctor > queueType;
+	typedef priority_queue<Record *, vector<Record *>, RecordPtrSortDescFunctor > queueType;
 	vector<queueType *> _queues;
 	static const int NUM_QUEUES = 3;
 
@@ -39,7 +39,7 @@ private:
 	//do, so we'll use a suggestion found in a forum, and put the enum values into a vector.
 	vector<Record::strandType> _strandIdxs;
 
-	int getMinIdx() const; //will return the idx of queue with the current min val.
+	int getMinIdx(); //will return the idx of queue with the current min val.
 
 };
 


### PR DESCRIPTION
Hi, I'm a maintainer for the Homebrew package manager and we are encountering build problems on Xcode 9 (macOS 10.12 and 10.13).

The issue lies in `StrandQueue` and presumably the new version of `clang`'s stricter handling of `const` rules. I do not think `const` member functions are allowed to "see" the same view of a class that a non-`const` member function does--or the standard library's implementation of `priority_queue` has changed, leading to the following build errors when any `const` member function from the `StrandQueue` class is called:

```
StrandQueue.cpp:13:26: note: in instantiation of template class 'std::__1::priority_queue<Record *, std::__1::vector<const Record *, std::__1::allocator<const Record *> >, RecordPtrSortDescFunctor>' requested here
                queueType *queue = new queueType();
                                       ^
StrandQueue.cpp:32:47: error: no member named 'top' in 'std::__1::priority_queue<Record *, std::__1::vector<const Record *, std::__1::allocator<const Record *> >, RecordPtrSortDescFunctor>'
        return const_cast<Record *>(_queues[minIdx]->top());
                                    ~~~~~~~~~~~~~~~  ^
```

and so on.

This patch fixes the build issues by purging `const` from the StrandQueue class. 

Fixes https://github.com/arq5x/bedtools2/issues/573
Fixes https://github.com/Homebrew/homebrew-science/issues/6334
c.f. https://github.com/Homebrew/homebrew-core/pull/18486