### PR TITLE
Support CIGARs with >65535 ops, via full clipping

### DIFF
--- a/src/utils/BamTools/src/api/internal/bam/BamReader_p.cpp
+++ b/src/utils/BamTools/src/api/internal/bam/BamReader_p.cpp
@@ -227,6 +227,90 @@ void BamReaderPrivate::LoadHeaderData(void) {
     m_header.Load(&m_stream);
 }
 
+static inline int bam_aux_type2size(int x)
+{
+    if (x == 'C' || x == 'c' || x == 'A') return 1;
+    else if (x == 'S' || x == 's') return 2;
+    else if (x == 'I' || x == 'i' || x == 'f') return 4;
+    else return 0;
+}
+
+static unsigned char *bam_aux_get(int aux_data_len, const unsigned char *aux_start, const char *tag)
+{
+    const unsigned char *p = aux_start;
+    while (p < aux_start + aux_data_len) {
+        if (p[0] == tag[0] && p[1] == tag[1]) return (unsigned char*)(p + 2);
+        p += 2; // skip tag
+        int type = *p++; // read type
+        if (type == 'B') {
+            int size = bam_aux_type2size(*p++); // read array type
+            unsigned len = (unsigned)p[0] | (unsigned)p[1]<<8 | (unsigned)p[2]<<16 | (unsigned)p[3]<<24;
+            p += 4; // skip the size field
+            p += len * size; // skip array
+        } else if (type == 'Z' || type == 'H') {
+            while (*p++ != 0) {} // skip NULL terminated string
+        } else {
+            p += bam_aux_type2size(type); // skip value
+        }
+    }
+    return NULL;
+}
+
+static inline int hts_reg2bin(int64_t beg, int64_t end, int min_shift, int n_lvls)
+{
+    int l, s = min_shift, t = ((1<<((n_lvls<<1) + n_lvls)) - 1) / 7;
+    for (--end, l = n_lvls; l > 0; --l, s += 3, t -= 1<<((l<<1)+l))
+        if (beg>>s == end>>s) return t + (beg>>s);
+    return 0;
+}
+
+bool BamReaderPrivate::Tag2Cigar(BamAlignment &a, RaiiBuffer &buf)
+{
+    if (a.RefID < 0 || a.Position < 0 || a.SupportData.NumCigarOperations != 1) return false;
+
+    const unsigned char *data = (const unsigned char*)buf.Buffer;
+    const unsigned data_len = a.SupportData.BlockLength - Constants::BAM_CORE_SIZE;
+    const unsigned char *p = data + a.SupportData.QueryNameLength; // the original CIGAR
+    unsigned cigar1 = (unsigned)p[0] | (unsigned)p[1]<<8 | (unsigned)p[2]<<16 | (unsigned)p[3]<<24;
+    if ((cigar1&0xf) != 4 || cigar1>>4 != a.SupportData.QuerySequenceLength) return false;
+
+    const int seq_offset = a.SupportData.QueryNameLength + a.SupportData.NumCigarOperations * 4;
+    const int aux_offset = seq_offset + (a.SupportData.QuerySequenceLength + 1) / 2 + a.SupportData.QuerySequenceLength;
+    unsigned char *CG = bam_aux_get(data_len - aux_offset, data + aux_offset, "CG");
+    if (CG == NULL || CG[0] != 'B' || CG[1] != 'I') return false;
+
+    const unsigned tag_cigar_len = (unsigned)CG[2] | (unsigned)CG[3]<<8 | (unsigned)CG[4]<<16 | (unsigned)CG[5]<<24;
+    if (tag_cigar_len == 0) return false;
+
+    // recalculate bin, as it may be incorrect if it was calculated by a tool unaware of the real CIGAR in tag
+    const unsigned tag_cigar_offset = CG - data + 6;
+    unsigned alignment_end = a.Position;
+    p = data + tag_cigar_offset;
+    for (unsigned i = 0; i < tag_cigar_len * 4; i += 4, p += 4) {
+        unsigned cigar1 = (unsigned)p[0] | (unsigned)p[1]<<8 | (unsigned)p[2]<<16 | (unsigned)p[3]<<24;
+        int op = cigar1 & 0xf;
+        if (op == 0 || op == 2 || op == 3 || op == 7 || op == 8)
+            alignment_end += cigar1 >> 4;
+    }
+    a.Bin = hts_reg2bin(a.Position, alignment_end, 14, 5);
+
+    // populate new AllCharData
+    std::string new_data;
+    new_data.reserve(data_len - 12 + 1);
+    new_data.append((char*)data, a.SupportData.QueryNameLength); // query name
+    new_data.append((char*)data + tag_cigar_offset, tag_cigar_len * 4); // real CIGAR
+    new_data.append((char*)data + seq_offset, tag_cigar_offset - 8 - seq_offset); // seq, qual and tags before CG
+    const unsigned tag_cigar_end_offset = tag_cigar_offset + tag_cigar_len * 4;
+    if (tag_cigar_end_offset < data_len) // tags after CG, if there is any
+        new_data.append((char*)data + tag_cigar_end_offset, data_len - tag_cigar_end_offset);
+
+    // update member variables
+    a.SupportData.NumCigarOperations = tag_cigar_len;
+    a.SupportData.BlockLength -= 12;
+    memcpy(buf.Buffer, new_data.c_str(), buf.NumBytes - 12);
+    return true;
+}
+
 // populates BamAlignment with alignment data under file pointer, returns success/fail
 bool BamReaderPrivate::LoadNextAlignment(BamAlignment& alignment) {
 
@@ -272,10 +356,13 @@ bool BamReaderPrivate::LoadNextAlignment(BamAlignment& alignment) {
 
     // read in character data - make sure proper data size was read
     bool readCharDataOK = false;
-    const unsigned int dataLength = alignment.SupportData.BlockLength - Constants::BAM_CORE_SIZE;
+    unsigned int dataLength = alignment.SupportData.BlockLength - Constants::BAM_CORE_SIZE;
     RaiiBuffer allCharData(dataLength);
 
     if ( m_stream.Read(allCharData.Buffer, dataLength) == dataLength ) {
+
+        if (Tag2Cigar(alignment, allCharData))
+            dataLength -= 12;
 
         // store 'allCharData' in supportData structure
         alignment.SupportData.AllCharData.assign((const char*)allCharData.Buffer, dataLength);

--- a/src/utils/BamTools/src/api/internal/bam/BamReader_p.h
+++ b/src/utils/BamTools/src/api/internal/bam/BamReader_p.h
@@ -54,6 +54,7 @@ class BamReaderPrivate {
         // access alignment data
         bool GetNextAlignment(BamAlignment& alignment);
         bool GetNextAlignmentCore(BamAlignment& alignment);
+        bool Tag2Cigar(BamAlignment &alignment, RaiiBuffer &buf);
 
         // access auxiliary data
         std::string GetHeaderText(void) const;


### PR DESCRIPTION
The current BAM format does not support CIGARs with >65535 operators. To solve this issue, minimap2 has an option `-L` to move long cigar in its binary form to a new tag "CG" and put a fake full clipping CIGAR at the original place. This will make most existing tools work with minimap2 output. However, existing tools, including the current bedtools2, that read CIGAR will treat such alignments essentially as unmapped. This PR enables bedtools2 to properly work with long-cigar data. samtools/htsjdk#1003 and samtools/htslib#560 are implementing the same strategy. Precompiled samtools and htsjdk can be found at [here](http://lh3lh3.users.sourceforge.net/data/cigar-64k/). That link also provides sample SAM/BAM that can be used for testing.