### PR TITLE
Stop shifting from extending past genome boundaries

### DIFF
--- a/src/shiftBed/shiftBed.cpp
+++ b/src/shiftBed/shiftBed.cpp
@@ -70,7 +70,7 @@ void BedShift::AddShift(BED &bed) {
 
   if ((bed.end + shift) <= 0)
     bed.end = 1;
-  else if ((bed.start + shift) > chromSize)
+  else if ((bed.end + shift) > chromSize)
     bed.end = chromSize;
   else
     bed.end = bed.end + shift;


### PR DESCRIPTION
When provided with a genome file, shift was still creating
intervals that extended past the last base pair.
See issue #599.