### PR TITLE
Ditch bizarre inclusion-then-mock-out of matplotlib from sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,8 +27,7 @@ sys.path.append(os.path.abspath('pyplots'))
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 
               'sphinx.ext.intersphinx', 'sphinx.ext.todo', 
               'sphinx.ext.coverage', 'sphinx.ext.pngmath', 
-              'sphinx.ext.ifconfig', 'sphinx.ext.viewcode',
-			        'matplotlib.sphinxext.plot_directive']
+              'sphinx.ext.ifconfig', 'sphinx.ext.viewcode']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['templates']
@@ -224,24 +223,3 @@ man_pages = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'bedtools': ('http://bedtools.readthedocs.org/en/latest/', None)}
-
-class Mock(object):
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def __call__(self, *args, **kwargs):
-        return Mock()
-
-    @classmethod
-    def __getattr__(cls, name):
-        if name in ('__file__', '__path__'):
-            return '/dev/null'
-        elif name[0] == name[0].upper():
-            return type(name, (), {})
-        else:
-            return Mock()
-
-MOCK_MODULES = ['numpy', 'matplotlib', 'matplotlib.pyplot', 
-                'matplotlib.sphinxext', 'matplotlib.sphinxext.plot_directive']
-for mod_name in MOCK_MODULES:
-    sys.modules[mod_name] = Mock()


### PR DESCRIPTION
A long time ago, commit ff358b3 - "add plotting to conf.py" -
added several plotting-related sphinx modules provided by
matplotlib to the sphinx config. Notably, it did not actually
add any *use* of these modules, so far as I can tell. Neither
did anything else later, again so far as I can tell.

Bizarrely, commit 9323618 - which followed it a month later -
proceeded to *mock these modules and their dependencies right
back out again*.

I have no idea what the idea was here, but it seems rather
weird. More to the point, it breaks build of the docs with
recent Sphinx, as this artisanal Mock() implementation is not
iterable:

Exception occurred:
  File "/usr/lib/python2.7/site-packages/sphinx/registry.py", line 225, in load_extension
    app.extensions[extname] = Extension(extname, mod, **metadata)
TypeError: 'Mock' object is not iterable

So, let's throw out this entire edifice of zaniness. The docs
build just fine with the remaining matplotlib module (the others
got taken out over the years) cut out from the extensions list,
and the whole weird Mock bit chopped.

Signed-off-by: Adam Williamson <awilliam@redhat.com>