### PR TITLE
Mark the STL set compare operators as const.

### DIFF
--- a/src/utils/BamTools/src/api/algorithms/Sort.h
+++ b/src/utils/BamTools/src/api/algorithms/Sort.h
@@ -76,7 +76,7 @@ struct API_EXPORT Sort {
         { }
 
         // comparison function
-        bool operator()(const BamTools::BamAlignment& lhs, const BamTools::BamAlignment& rhs) {
+        bool operator()(const BamTools::BamAlignment& lhs, const BamTools::BamAlignment& rhs) const {
             return sort_helper(m_order, lhs.Name, rhs.Name);
         }
 
@@ -112,7 +112,7 @@ struct API_EXPORT Sort {
         { }
 
         // comparison function
-        bool operator()(const BamTools::BamAlignment& lhs, const BamTools::BamAlignment& rhs) {
+        bool operator()(const BamTools::BamAlignment& lhs, const BamTools::BamAlignment& rhs) const {
 
             // force unmapped aligmnents to end
             if ( lhs.RefID == -1 ) return false;
@@ -161,7 +161,7 @@ struct API_EXPORT Sort {
         { }
 
         // comparison function
-        bool operator()(const BamTools::BamAlignment& lhs, const BamTools::BamAlignment& rhs) {
+        bool operator()(const BamTools::BamAlignment& lhs, const BamTools::BamAlignment& rhs) const {
 
             // force alignments without tag to end
             T lhsTagValue;

--- a/src/utils/BamTools/src/api/internal/bam/BamMultiMerger_p.h
+++ b/src/utils/BamTools/src/api/internal/bam/BamMultiMerger_p.h
@@ -61,7 +61,7 @@ struct MergeItemSorter : public std::binary_function<MergeItem, MergeItem, bool>
             : m_comp(comp)
         { }
 
-        bool operator()(const MergeItem& lhs, const MergeItem& rhs) {
+        bool operator()(const MergeItem& lhs, const MergeItem& rhs) const {
             const BamAlignment& l = *lhs.Alignment;
             const BamAlignment& r = *rhs.Alignment;
             return m_comp(l,r);


### PR DESCRIPTION
The C++ standard demands so, and the code breaks w/ clang + libc++ + c++17 mode.