### PR TITLE
Changing default behavior of BedAnnotate to preserving input lines order

### DIFF
--- a/src/utils/bedFile/bedFile.h
+++ b/src/utils/bedFile/bedFile.h
@@ -46,18 +46,17 @@ typedef uint32_t UINT;
 //*************************************************
 // Genome binning constants
 //*************************************************
-const BIN      _numBins   = 37450;
 const BINLEVEL _binLevels = 7;
 
-// bins range in size from 16kb to 512Mb
-// Bin  0          spans 512Mbp,   # Level 1
-// Bins 1-8        span 64Mbp,     # Level 2
-// Bins 9-72       span 8Mbp,      # Level 3
-// Bins 73-584     span 1Mbp       # Level 4
-// Bins 585-4680   span 128Kbp     # Level 5
-// Bins 4681-37449 span 16Kbp      # Level 6
+// bins range in size from 2kb to 512Mb
+// Bin  0            spans 512Mbp,  # Level 0
+// Bins 1-8          span 64Mbp,    # Level 1
+// Bins 9-72         span 8Mbp,     # Level 2
+// Bins 73-584       span 1Mbp      # Level 3
+// Bins 585-4680     span 128Kbp    # Level 4
+// Bins 4681-37448   span 16Kbp     # Level 5
+// Bins 37449-299592 span 2Kbp      # Level 6
 const BIN _binOffsetsExtended[] = {32678+4096+512+64+8+1, 4096+512+64+8+1, 512+64+8+1, 64+8+1, 8+1, 1, 0};
-//const BIN _binOffsetsExtended[] = {4096+512+64+8+1, 4096+512+64+8+1, 512+64+8+1, 64+8+1, 8+1, 1, 0};
 
 const USHORT _binFirstShift = 14;       /* How much to shift to get to finest bin. */
 const USHORT _binNextShift  = 3;        /* How much to shift to get to next larger bin. */
@@ -434,7 +433,10 @@ public:
     // vector of BEDCOVLISTs
     void loadBedCovListFileIntoMap();
 
-    // load a BED file into a map keyed by chrom. value is vector of BEDs
+    // load a BED file into a vector of BEDCOVLISTs
+    void loadBedCovListFileIntoVector();
+
+    // load and sort a BED file into a map keyed by chrom. value is vector of BEDs
     void loadBedFileIntoMapNoBin();
 
     // load a BED file into a vector of BEDs
@@ -475,8 +477,8 @@ public:
     // Given a chrom, start, end and strand for a single feature,
     // increment a the number of hits for each feature in B file
     // that the feature overlaps
-    void countListHits(const BED &a, int index, 
-                       bool sameStrand, bool diffStrand);
+    void countListHitsWithoutBins(const BED &a, int index,
+                                  bool sameStrand, bool diffStrand);
     
     
     // return the total length of all the intervals in the file.
@@ -501,6 +503,7 @@ public:
     masterBedMap         bedMap;
     bedVector            bedList;
     masterBedMapNoBin    bedMapNoBin;
+    bedCovListVector     bedCovListFlat;
     
     BedLineStatus _status;
     int _lineNum;


### PR DESCRIPTION
- BedAnnotate now preserves initial sort order.
- Adjusted comments in bedFile.h to better represent actual binning model used for last several years.

This commit alter BedAnnotate and functions, specific to it, so that new version of code will preserve in output file lines order from input file. Currently, output lines are sorted, this is not tweakable behavior, and data are forced to be re-sorted in a rare manner, which is not even supported by SortBed, tool specialized for sorting.

Detailed description:
In before AnnotateBed used genomic binning. Being isolated tool, it never used binning in any way. However, bare usage of binning forced AnnotateBed to re-sort input lines. First - chromosomes; then - from bigger to smaller bins; at last - per start coordinate within a bin. It creates unexpected from documentation changes in output file, see issue #622 (however, in the issue itself it is pointed out incorrectly, why the problem occurs).
Specifically, the output creates an illusion, that AnnotateBed sorts data in chrom:pos order. This was never mentioned in documentation, and thus there was no way to change this behavior. However, actual sorting algorithm is more complicated and involves genomic binning (see below and commit). This results in visually arbitrary sorting of output data, which is impossible to switch off.

Rationale for PR:
1. Unix-way: given that separate tool for sorting, SortBed, exists, other tools in package should not re-sort bed files during processing.
2. Control over execution: if other tools re-sort files anyways, there should be a way to change or disable sorting behavior, but there is no such way for AnnotateBed.
3. Enforced mode is not the common one: currently following sorting model is enforced by AnnotatedBed: sort by chrom -> genomic bin -> position. This model, to my knowledge, is not widely accepted, and chrom -> position is used much more common. In fact, above mentioned SortBed from the same package does NOT support such model, which probably means this current model is not a reasonable way to order lines in output file. Thus, current way of AnnotateBed processing introduces  a confusing input lines re-ordering for no particular reason or benefit.

There were several ways to improve situation:
a. allow to switch off current sorting by additional parameter.
b. preserve initial kines order instead of any sorting (including current).
c. allow to select arbitrary mode of sorting.
Solutions (a) and (c) are subject to the problem described in rationale (1) - it is better to chain SortBed + AnnotateBed, if sorting is required.
Solution (a) is more complex than (b). Additionally, due to rationale (3) it seems unlikely that saving current sorting can be beneficial. So, (a) would introduce unnecessary complexity.
Thus, this PR implements solution (b).