### PR TITLE
InflateStreamBuf: Only realloc() when buffer is being enlarged

### DIFF
--- a/src/utils/general/InflateStreamBuf.h
+++ b/src/utils/general/InflateStreamBuf.h
@@ -31,6 +31,7 @@ public:
 		strm.avail_in = 0;
 		strm.next_in = Z_NULL;
 
+		bufsiz=GZBUFSIZ;
 		buffer=(char*)std::malloc(GZBUFSIZ*sizeof(char));
 		if(buffer==NULL) {
 			throw ("out of memory");
@@ -73,7 +74,6 @@ public:
 		strm.next_in=buffin;
 	   /* run inflate() on input until output buffer not full */
 		unsigned int total=0;
-		_currentOutBufSize = 0;
 		do {
 			strm.avail_out = GZBUFSIZ;
 			strm.next_out = buffout;
@@ -99,9 +99,10 @@ public:
 			}
 
 			unsigned int have = GZBUFSIZ - strm.avail_out;
-			if (have > 0) {
+			if (total + have > bufsiz) {
 				buffer=(char*)std::realloc(buffer,sizeof(char)*(total+have));
 				if(buffer==NULL) throw ("out of memory");
+				bufsiz = total + have;
 			}
 			memcpy((void*)&buffer[total], &buffout[0], sizeof(char)*have);
 			total+=have;
@@ -109,7 +110,6 @@ public:
 
 
 		setg(buffer, buffer, &buffer[total]);
-		_currentOutBufSize = total;
 
 		return total==0?EOF:this->buffer[0];
 	}
@@ -119,9 +119,9 @@ protected:
 	unsigned char buffin[GZBUFSIZ];
 	unsigned char buffout[GZBUFSIZ];
 	char* buffer;
+	size_t bufsiz;
 	z_stream strm;
 	int status_flag;
-	int _currentOutBufSize;
 };
 
 


### PR DESCRIPTION
An updated version of the fix for #643. Tracking the buffer size avoids `realloc(buffer,0)` and thus fixes the buffering bug. This version also reduces the number of realloc() calls made overall, by reusing the existing buffer where possible. So a small speed increase (and no memory use increase, as each `buffin` GZBUFSIZ bytes mostly decompresses to a similar size).

No worries if you don't want to apply this one :smile: