### PR TITLE
Update HTSlib #include base; fix printf(…, CHRPOS, …) warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ INCLUDES =	-I"$(REAL_SRC_DIR)/utils/bedFile" \
 				-I"$(REAL_SRC_DIR)/utils/RecordOutputMgr" \
 				-I"$(REAL_SRC_DIR)/utils/ToolBase" \
 				-I"$(REAL_SRC_DIR)/utils/driver" \
-				-I"$(REAL_SRC_DIR)/utils/htslib/htslib"
+				-I"$(REAL_SRC_DIR)/utils/htslib"
 
 
 all: print_banner $(OBJ_DIR) $(BIN_DIR) autoversion $(UTIL_SUBDIRS) $(SUBDIRS)

--- a/src/bamToBed/bamToBed.cpp
+++ b/src/bamToBed/bamToBed.cpp
@@ -501,7 +501,7 @@ void PrintBed(const BamAlignment &bam,  const RefVector &refs,
             BED curr = bedBlocks[i];
 
             if (bamTag == "") {
-                printf("%s\t%d\t%d\t%s\t%d\t%s\n", 
+                printf("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%d\t%s\n",
                        chrom.c_str(), 
                        curr.start,
                        curr.end,
@@ -567,21 +567,22 @@ void PrintBed12(const BamAlignment &bam, const RefVector &refs,
     }
 
     // write the colors, etc.
-    printf("%d\t%d\t%s\t%d\t", (int)bam.Position, alignmentEnd, 
+    printf("%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%d\t",
+                               (CHRPOS)bam.Position, alignmentEnd,
                                color.c_str(), (int) bedBlocks.size());
 
     // now write the lengths portion
     unsigned int b;
     for (b = 0; b < bedBlocks.size() - 1; ++b) {
-        printf("%d,", bedBlocks[b].end - bedBlocks[b].start);
+        printf("%" PRId_CHRPOS ",", bedBlocks[b].end - bedBlocks[b].start);
     }
-    printf("%d\t", bedBlocks[b].end - bedBlocks[b].start);
+    printf("%" PRId_CHRPOS "\t", bedBlocks[b].end - bedBlocks[b].start);
 
     // now write the starts portion
     for (b = 0; b < bedBlocks.size() - 1; ++b) {
-        printf("%d,", bedBlocks[b].start - bam.Position);
+        printf("%" PRId_CHRPOS ",", bedBlocks[b].start - bam.Position);
     }
-    printf("%d\n", bedBlocks[b].start - bam.Position);
+    printf("%" PRId_CHRPOS "\n", bedBlocks[b].start - bam.Position);
 }
 
 

--- a/src/bed12ToBed6/bed12ToBed6.cpp
+++ b/src/bed12ToBed6/bed12ToBed6.cpp
@@ -144,16 +144,19 @@ void ProcessBed(istream &bedInput, BedFile *bed) {
 
             for (int i = 0; i < (int) bedBlocks.size(); ++i) {
                 if (addBlockNums == false) {
-                    printf ("%s\t%ld\t%ld\t%s\t%s\t%s\n", bedBlocks[i].chrom.c_str(), bedBlocks[i].start, bedBlocks[i].end, bedBlocks[i].name.c_str(),
-                                                        bedBlocks[i].score.c_str(), bedBlocks[i].strand.c_str());
+                    printf("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s\n",
+                        bedBlocks[i].chrom.c_str(), bedBlocks[i].start, bedBlocks[i].end, bedBlocks[i].name.c_str(),
+                        bedBlocks[i].score.c_str(), bedBlocks[i].strand.c_str());
                 }
                 else {
                     if (bedBlocks[i].strand == "+")
-                        printf ("%s\t%ld\t%ld\t%s\t%d\t%s\n", bedBlocks[i].chrom.c_str(), bedBlocks[i].start, bedBlocks[i].end, bedBlocks[i].name.c_str(),
-                                                        i+1, bedBlocks[i].strand.c_str());
+                        printf("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%d\t%s\n",
+                            bedBlocks[i].chrom.c_str(), bedBlocks[i].start, bedBlocks[i].end, bedBlocks[i].name.c_str(),
+                            i+1, bedBlocks[i].strand.c_str());
                     else 
-                        printf ("%s\t%ld\t%ld\t%s\t%d\t%s\n", bedBlocks[i].chrom.c_str(), bedBlocks[i].start, bedBlocks[i].end, bedBlocks[i].name.c_str(),
-                                                        (int) ((bedBlocks.size())-i), bedBlocks[i].strand.c_str());
+                        printf("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%d\t%s\n",
+                            bedBlocks[i].chrom.c_str(), bedBlocks[i].start, bedBlocks[i].end, bedBlocks[i].name.c_str(),
+                            (int) ((bedBlocks.size())-i), bedBlocks[i].strand.c_str());
                 }
             }
         }

--- a/src/getOverlap/getOverlap.cpp
+++ b/src/getOverlap/getOverlap.cpp
@@ -187,7 +187,7 @@ void ComputeOverlaps(istream &input, short &s1Col, short &e1Col, short &s2Col, s
                 e2End != inFields[e2Col-1].c_str()) {
 
                 overlap = overlaps(s1, e1, s2, e2);
-                printf("%s\t%ld\n", inLine.c_str(), overlap);
+                printf("%s\t%" PRId_CHRPOS "\n", inLine.c_str(), overlap);
             }
             else {
                 cerr << "One of your columns appears to be non-numeric at line " << lineNum << ". Exiting..." << endl << endl;

--- a/src/nucBed/nucBed.cpp
+++ b/src/nucBed/nucBed.cpp
@@ -53,13 +53,13 @@ void NucBed::ReportDnaProfile(const BED& bed, const string &sequence, CHRPOS seq
     // report AT and GC content
     printf("%f\t%f\t",(float)(a+t)/seqLength, (float)(c+g)/seqLength);
     // report raw nucleotide counts
-    printf("%ld\t%ld\t%ld\t%ld\t%ld\t%ld\t%ld",a,c,g,t,n,other,seqLength);
+    printf("%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%" PRId_CHRPOS,a,c,g,t,n,other,seqLength);
     // add the original sequence if requested.
 
     if (_printSeq)
         printf("\t%s",sequence.c_str());
     if (_hasPattern)
-        printf("\t%d",userPatternCount);
+        printf("\t%" PRId_CHRPOS,userPatternCount);
     printf("\n");
 
 }

--- a/src/pairToPair/pairToPair.cpp
+++ b/src/pairToPair/pairToPair.cpp
@@ -157,10 +157,11 @@ bool PairToPair::FindHitsOnBothEnds(const BEDPE &a, const vector<MATE> &qualityH
 
             if (_searchType == "both") {
                 _bedA->reportBedPETab(a);
-                printf("%s\t%ld\t%ld\t%s\t%ld\t%ld\t%s\t%s\t%s\t%s", b1.bed.chrom.c_str(), b1.bed.start, b1.bed.end,
-                                                                   b2.bed.chrom.c_str(), b2.bed.start, b2.bed.end,
-                                                                   b1.bed.name.c_str(), b1.bed.score.c_str(),
-                                                                   b1.bed.strand.c_str(), b2.bed.strand.c_str());
+                printf("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s\t%s",
+                    b1.bed.chrom.c_str(), b1.bed.start, b1.bed.end,
+                    b2.bed.chrom.c_str(), b2.bed.start, b2.bed.end,
+                    b1.bed.name.c_str(), b1.bed.score.c_str(),
+                    b1.bed.strand.c_str(), b2.bed.strand.c_str());
                 for (size_t i = 0; i < b1.bed.other_idxs.size(); ++i)
                     printf("\t%s", b1.bed.fields[b1.bed.other_idxs[i]].c_str());
                 printf("\n");
@@ -191,10 +192,11 @@ void PairToPair::FindHitsOnEitherEnd(const BEDPE &a, const vector<MATE> &quality
                 MATE b2 = m->second[1];
 
                 _bedA->reportBedPETab(a);
-                printf("%s\t%ld\t%ld\t%s\t%ld\t%ld\t%s\t%s\t%s\t%s", b1.bed.chrom.c_str(), b1.bed.start, b1.bed.end,
-                                                                   b2.bed.chrom.c_str(), b2.bed.start, b2.bed.end,
-                                                                   b1.bed.name.c_str(), b1.bed.score.c_str(),
-                                                                   b1.bed.strand.c_str(), b2.bed.strand.c_str());
+                printf("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s\t%s",
+                    b1.bed.chrom.c_str(), b1.bed.start, b1.bed.end,
+                    b2.bed.chrom.c_str(), b2.bed.start, b2.bed.end,
+                    b1.bed.name.c_str(), b1.bed.score.c_str(),
+                    b1.bed.strand.c_str(), b2.bed.strand.c_str());
                 for (size_t i = 0; i < b1.bed.other_idxs.size(); ++i)
                     printf("\t%s", b1.bed.fields[b1.bed.other_idxs[i]].c_str());
                 printf("\n");
@@ -203,10 +205,11 @@ void PairToPair::FindHitsOnEitherEnd(const BEDPE &a, const vector<MATE> &quality
                 MATE b1 = m->second[0];
 
                 _bedA->reportBedPETab(a);
-                printf("%s\t%ld\t%ld\t%s\t%ld\t%ld\t%s\t%s\t%s\t%s", b1.bed.chrom.c_str(), b1.bed.start, b1.bed.end,
-                                                                   b1.mate->bed.chrom.c_str(), b1.mate->bed.start, b1.mate->bed.end,
-                                                                   b1.bed.name.c_str(), b1.bed.score.c_str(),
-                                                                   b1.bed.strand.c_str(), b1.mate->bed.strand.c_str());
+                printf("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s\t%s",
+                    b1.bed.chrom.c_str(), b1.bed.start, b1.bed.end,
+                    b1.mate->bed.chrom.c_str(), b1.mate->bed.start, b1.mate->bed.end,
+                    b1.bed.name.c_str(), b1.bed.score.c_str(),
+                    b1.bed.strand.c_str(), b1.mate->bed.strand.c_str());
                 for (size_t i = 0; i < b1.bed.other_idxs.size(); ++i)
                     printf("\t%s", b1.bed.fields[b1.bed.other_idxs[i]].c_str());
                 printf("\n");

--- a/src/randomBed/randomBed.cpp
+++ b/src/randomBed/randomBed.cpp
@@ -71,7 +71,8 @@ void BedRandom::Generate()
         numGenerated++;
         // flip a coin for strand
         (rand() / double(RAND_MAX)) > 0.5 ? strand = '+' : strand = '-';
-        printf("%s\t%ld\t%ld\t%d\t%ld\t%c\n", chrom.c_str(), start, end, numGenerated, end-start, strand);
+        printf("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%d\t%" PRId_CHRPOS "\t%c\n",
+            chrom.c_str(), start, end, numGenerated, end-start, strand);
     }
 }
 

--- a/src/randomBed/randomBed.h
+++ b/src/randomBed/randomBed.h
@@ -17,6 +17,7 @@
 #include <map>
 #include <cstdlib>
 #include <ctime>
+#include <inttypes.h>
 #include <sys/time.h>
 #include <unistd.h>
 #include <sys/types.h>
@@ -26,6 +27,8 @@ using namespace std;
 const int MAX_TRIES = 1000000;
 
 typedef int64_t CHRPOS;
+
+#define PRId_CHRPOS PRId64
 
 //************************************************
 // Class methods and elements

--- a/src/utils/BamTools/include/BamAlignment.hpp
+++ b/src/utils/BamTools/include/BamAlignment.hpp
@@ -5,7 +5,7 @@
 #include <cstring>
 namespace BamTools {
 	const static char cigar_ops_as_chars[] = { 'M', 'I', 'D', 'N', 'S', 'H', 'P', '=', 'X', 'B' };
-	static std::string _mkstr(const uint8_t* what) { return std::string((const char*)what + 1); }
+	static inline std::string _mkstr(const uint8_t* what) { return std::string((const char*)what + 1); }
 	struct CigarOp {
 	  
 		char     Type;   //!< CIGAR operation type (MIDNSHPX=)

--- a/src/utils/BamTools/include/BamReader.hpp
+++ b/src/utils/BamTools/include/BamReader.hpp
@@ -2,10 +2,10 @@
 #define __HTSLIBPP_BAMREADER_HPP__
 #include <BamAlignment.hpp>
 #include <SamHeader.hpp>
-#include <cram.h>
-#include <sam.h>
-#include <hts.h>
-#include <hfile.h>
+#include <htslib/cram.h>
+#include <htslib/sam.h>
+#include <htslib/hts.h>
+#include <htslib/hfile.h>
 #include <stdint.h>
 #include <string>
 #include <queue>

--- a/src/utils/BamTools/include/BamReader.hpp
+++ b/src/utils/BamTools/include/BamReader.hpp
@@ -137,9 +137,6 @@ namespace BamTools {
 		std::vector<_SamFile*> _files;
 		std::vector<SamHeader> _hdrs;
 		std::priority_queue<std::pair<_MetaData, bam1_t*>, std::vector<std::pair<_MetaData, bam1_t*> >, _Comp> _queue;
-#ifdef WITH_HTS_CB_API
-		hFILE_callback_ops _hops;
-#endif
 		std::string _error_str;
 
 		bool _read_sam_file(_SamFile* file)

--- a/src/utils/BamTools/include/BamWriter.hpp
+++ b/src/utils/BamTools/include/BamWriter.hpp
@@ -1,6 +1,7 @@
 #ifndef __HTSLIBPP_BAM_WRITER_HPP__
 #define __HTSLIBPP_BAM_WRITER_HPP__
 #include <string>
+#include <stdexcept>
 #include <htslib/sam.h>
 #include <SamHeader.hpp>
 #include <BamAlignment.hpp>
@@ -48,7 +49,8 @@ namespace BamTools {
 			if(sync_data)
 				al.SyncExtraData();
 			const bam1_t* bam = al.HtsObj();
-			sam_write1(_fp, _hdr.GetHeaderStruct(), bam);
+			if (sam_write1(_fp, _hdr.GetHeaderStruct(), bam) < 0)
+				throw std::runtime_error("can't write alignment record");
 		}
 		void SetCompressionMode(CompressionMode mode)
 		{

--- a/src/utils/BamTools/include/BamWriter.hpp
+++ b/src/utils/BamTools/include/BamWriter.hpp
@@ -1,8 +1,7 @@
 #ifndef __HTSLIBPP_BAM_WRITER_HPP__
 #define __HTSLIBPP_BAM_WRITER_HPP__
 #include <string>
-#include <cram.h>
-#include <sam.h>
+#include <htslib/sam.h>
 #include <SamHeader.hpp>
 #include <BamAlignment.hpp>
 namespace BamTools {

--- a/src/utils/BamTools/include/SamHeader.hpp
+++ b/src/utils/BamTools/include/SamHeader.hpp
@@ -2,7 +2,7 @@
 #define __HTSLIBPP_SAMHEADER_H__
 #include <stdint.h>
 #include <string>
-#include <sam.h>
+#include <htslib/sam.h>
 #include <vector>
 #include <string.h>
 #include <api/BamAux.h>

--- a/src/utils/BamTools/include/api/BamAlignment.h
+++ b/src/utils/BamTools/include/api/BamAlignment.h
@@ -1,3 +1,3 @@
-#include <sam.h>
+#include <htslib/sam.h>
 #include <SamHeader.hpp>
 #include <BamAlignment.hpp>

--- a/src/utils/BamTools/include/api/BamMultiReader.h
+++ b/src/utils/BamTools/include/api/BamMultiReader.h
@@ -1,4 +1,4 @@
-#include <sam.h>
+#include <htslib/sam.h>
 #include <string>
 #include  <vector>
 #include <BamReader.hpp>

--- a/src/utils/BamTools/include/api/BamWriter.h
+++ b/src/utils/BamTools/include/api/BamWriter.h
@@ -1,4 +1,4 @@
-#include <sam.h>
+#include <htslib/sam.h>
 #include <vector>
 #include <string>
 #include <BamAlignment.hpp>

--- a/src/utils/BinTree/BinTree.cpp
+++ b/src/utils/BinTree/BinTree.cpp
@@ -104,8 +104,8 @@ bool BinTree::addRecordToTree(Record *record)
 	binNumType binNum = getBin(startPos, endPos);
 
 	if (binNum < 0 || binNum >= NUM_BINS) {
-		fprintf(stderr, "ERROR: Received illegal bin number %lu from getBin call.\n"
-                                "Maximum values is: %lu\n"
+		fprintf(stderr, "ERROR: Received illegal bin number %" PRId_BINNUMTYPE " from getBin call.\n"
+                                "Maximum values is: %" PRId_BINNUMTYPE "\n"
                                 "This typically means that your coordinates are\n"
                                 "negative or too large to represent in the data\n"
                                 "structure bedtools uses to find intersections.", binNum, NUM_BINS);

--- a/src/utils/BinTree/BinTree.h
+++ b/src/utils/BinTree/BinTree.h
@@ -8,6 +8,7 @@
 #ifndef BINTREE_H_
 #define BINTREE_H_
 
+#include <inttypes.h>
 #include <stdint.h>
 #include <string>
 #include <set>
@@ -41,6 +42,8 @@ private:
     // BIN HANDLING
     //
         typedef int64_t binNumType;
+
+#define PRId_BINNUMTYPE PRId64
 
 	// bins range in size from 16kb to 32Gb
 	static const binNumType NUM_BIN_LEVELS = 8;

--- a/src/utils/FileRecordTools/FileReaders/InputStreamMgr.h
+++ b/src/utils/FileRecordTools/FileReaders/InputStreamMgr.h
@@ -13,7 +13,7 @@
 #include "string.h"
 #include "api/BamReader.h"
 
-#include <bgzf.h>
+#include <htslib/bgzf.h>
 #include <iostream>
 
 using namespace std;

--- a/src/utils/bedFile/bedFile.h
+++ b/src/utils/bedFile/bedFile.h
@@ -27,6 +27,7 @@
 #include <sstream>
 #include <cstring>
 #include <algorithm>
+#include <inttypes.h>
 #include <limits.h>
 #include <stdint.h>
 #include <cstdio>
@@ -42,6 +43,8 @@ typedef uint16_t BINLEVEL;
 typedef uint32_t BIN;
 typedef uint16_t USHORT;
 typedef uint32_t UINT;
+
+#define PRId_CHRPOS PRId64
 
 //*************************************************
 // Genome binning constants
@@ -936,24 +939,24 @@ public:
         // BED
         if (_isGff == false && _isVcf == false) {
             if (this->bedType == 3) {
-                printf ("%s\t%ld\t%ld\t", bed.chrom.c_str(), start, end);
+                printf ("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t", bed.chrom.c_str(), start, end);
             }
             else if (this->bedType == 4) {
-                printf ("%s\t%ld\t%ld\t%s\t", 
+                printf ("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t",
                     bed.chrom.c_str(), start, end, bed.name.c_str());
             }
             else if (this->bedType == 5) {
-                printf ("%s\t%ld\t%ld\t%s\t%s\t", 
+                printf ("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t",
                     bed.chrom.c_str(), start, end, 
                     bed.name.c_str(), bed.score.c_str());
             }
             else if (this->bedType == 6) {
-                printf ("%s\t%ld\t%ld\t%s\t%s\t%s\t", 
+                printf ("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s\t",
                     bed.chrom.c_str(), start, end, 
                     bed.name.c_str(), bed.score.c_str(), bed.strand.c_str());
             }
             else if (this->bedType > 6) {
-                printf ("%s\t%ld\t%ld\t%s\t%s\t%s\t", 
+                printf ("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s\t",
                     bed.chrom.c_str(), start, end, bed.name.c_str(),
                     bed.score.c_str(), bed.strand.c_str());
                 
@@ -968,7 +971,7 @@ public:
         }
         // VCF
         else if (_isGff == false && _isVcf == true) {
-            printf ("%s\t%ld\t", bed.chrom.c_str(), start+1);
+            printf ("%s\t%" PRId_CHRPOS "\t", bed.chrom.c_str(), start+1);
 
             vector<uint16_t>::const_iterator othIt  = bed.other_idxs.begin();
             vector<uint16_t>::const_iterator othEnd = bed.other_idxs.end();
@@ -980,14 +983,14 @@ public:
         else if (_isGff == true) {
             // "GFF-8"
             if (this->bedType == 8) {
-                printf ("%s\t%s\t%s\t%ld\t%ld\t%s\t%s\t%s\t", 
+                printf ("%s\t%s\t%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s\t",
                     bed.chrom.c_str(), bed.fields[bed.other_idxs[0]].c_str(),
                     bed.name.c_str(), start+1, end, bed.score.c_str(), 
                     bed.strand.c_str(), bed.fields[bed.other_idxs[1]].c_str());
             }
             // "GFF-9"
             else if (this->bedType == 9) {
-                printf ("%s\t%s\t%s\t%ld\t%ld\t%s\t%s\t%s\t%s\t", 
+                printf ("%s\t%s\t%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s\t%s\t",
                     bed.chrom.c_str(), bed.fields[bed.other_idxs[0]].c_str(),
                     bed.name.c_str(), start+1, end,
                     bed.score.c_str(), bed.strand.c_str(),
@@ -1022,24 +1025,24 @@ public:
         //BED
         if (_isGff == false && _isVcf == false) {
             if (this->bedType == 3) {
-                fprintf(out,"%s\t%ld\t%ld\n", bed.chrom.c_str(), start, end);
+                fprintf(out,"%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\n", bed.chrom.c_str(), start, end);
             }
             else if (this->bedType == 4) {
-                fprintf(out,"%s\t%ld\t%ld\t%s\n", 
+                fprintf(out,"%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\n",
                     bed.chrom.c_str(), start, end, bed.name.c_str());
             }
             else if (this->bedType == 5) {
-                fprintf(out,"%s\t%ld\t%ld\t%s\t%s\n", 
+                fprintf(out,"%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\n",
                     bed.chrom.c_str(), start, end, 
                     bed.name.c_str(), bed.score.c_str());
             }
             else if (this->bedType == 6) {
-                fprintf(out,"%s\t%ld\t%ld\t%s\t%s\t%s\n", 
+                fprintf(out,"%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s\n",
                     bed.chrom.c_str(), start, end, bed.name.c_str(),
                     bed.score.c_str(), bed.strand.c_str());
             }
             else if (this->bedType > 6) {
-                fprintf(out,"%s\t%ld\t%ld\t%s\t%s\t%s", 
+                fprintf(out,"%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s",
                     bed.chrom.c_str(), start, end, bed.name.c_str(),
                     bed.score.c_str(), bed.strand.c_str());
 
@@ -1055,7 +1058,7 @@ public:
         }
         // VCF
         else if (_isGff == false && _isVcf == true) {
-            fprintf(out,"%s\t%ld", bed.chrom.c_str(), start+1);
+            fprintf(out,"%s\t%" PRId_CHRPOS, bed.chrom.c_str(), start+1);
 
             vector<uint16_t>::const_iterator othIt  = bed.other_idxs.begin();
             vector<uint16_t>::const_iterator othEnd = bed.other_idxs.end();
@@ -1068,7 +1071,7 @@ public:
         else if (_isGff == true) {
             // "GFF-8"
             if (this->bedType == 8) {
-                fprintf (out,"%s\t%s\t%s\t%ld\t%ld\t%s\t%s\t%s\n", 
+                fprintf (out,"%s\t%s\t%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s\n",
                     bed.chrom.c_str(), bed.fields[bed.other_idxs[0]].c_str(),
                     bed.name.c_str(), start+1, end,
                     bed.score.c_str(), bed.strand.c_str(),
@@ -1076,7 +1079,7 @@ public:
             }
             // "GFF-9"
             else if (this->bedType == 9) {
-                fprintf (out,"%s\t%s\t%s\t%ld\t%ld\t%s\t%s\t%s\t%s\n", 
+                fprintf (out,"%s\t%s\t%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s\t%s\n",
                     bed.chrom.c_str(), bed.fields[bed.other_idxs[0]].c_str(),
                     bed.name.c_str(), start+1, end,
                     bed.score.c_str(), bed.strand.c_str(),
@@ -1112,24 +1115,24 @@ public:
         // BED
         if (_isGff == false && _isVcf == false) {
             if (this->bedType == 3) {
-                printf ("%s\t%d\t%d\t", bed.chrom.c_str(), start, end);
+                printf ("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t", bed.chrom.c_str(), start, end);
             }
             else if (this->bedType == 4) {
-                printf ("%s\t%d\t%d\t%s\t", 
+                printf ("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t",
                     bed.chrom.c_str(), start, end, bed.name.c_str());
             }
             else if (this->bedType == 5) {
-                printf ("%s\t%d\t%d\t%s\t%s\t", 
+                printf ("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t",
                     bed.chrom.c_str(), start, end, 
                     bed.name.c_str(), bed.score.c_str());
             }
             else if (this->bedType == 6) {
-                printf ("%s\t%d\t%d\t%s\t%s\t%s\t", 
+                printf ("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s\t",
                     bed.chrom.c_str(), start, end, bed.name.c_str(),
                     bed.score.c_str(), bed.strand.c_str());
             }
             else if (this->bedType > 6) {
-                printf ("%s\t%d\t%d\t%s\t%s\t%s\t", 
+                printf ("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s\t",
                     bed.chrom.c_str(), start, end, bed.name.c_str(),
                     bed.score.c_str(), bed.strand.c_str());
                 
@@ -1144,7 +1147,7 @@ public:
         }
         // VCF
         else if (_isGff == false && _isVcf == true) {
-            printf ("%s\t%d\t", bed.chrom.c_str(), bed.start+1);
+            printf ("%s\t%" PRId_CHRPOS "\t", bed.chrom.c_str(), bed.start+1);
             vector<uint16_t>::const_iterator othIt  = bed.other_idxs.begin();
             vector<uint16_t>::const_iterator othEnd = bed.other_idxs.end();
             for ( ; othIt != othEnd; ++othIt) {
@@ -1155,7 +1158,7 @@ public:
         else if (_isGff == true) {
             // "GFF-8"
             if (this->bedType == 8) {
-                printf ("%s\t%s\t%s\t%d\t%d\t%s\t%s\t%s\t", 
+                printf ("%s\t%s\t%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s\t",
                     bed.chrom.c_str(), bed.fields[bed.other_idxs[0]].c_str(),
                     bed.name.c_str(), start+1, end,
                     bed.score.c_str(), bed.strand.c_str(),
@@ -1163,7 +1166,7 @@ public:
             }
             // "GFF-9"
             else if (this->bedType == 9) {
-                printf ("%s\t%s\t%s\t%d\t%d\t%s\t%s\t%s\t%s\t", 
+                printf ("%s\t%s\t%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s\t%s\t",
                     bed.chrom.c_str(), bed.fields[bed.other_idxs[0]].c_str(),
                     bed.name.c_str(), start+1, end,
                     bed.score.c_str(), bed.strand.c_str(),
@@ -1196,24 +1199,24 @@ public:
         // BED
         if (_isGff == false && _isVcf == false) {
             if (this->bedType == 3) {
-                printf ("%s\t%d\t%d\n", bed.chrom.c_str(), start, end);
+                printf ("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\n", bed.chrom.c_str(), start, end);
             }
             else if (this->bedType == 4) {
-                printf ("%s\t%d\t%d\t%s\n", 
+                printf ("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\n",
                     bed.chrom.c_str(), start, end, bed.name.c_str());
             }
             else if (this->bedType == 5) {
-                printf ("%s\t%d\t%d\t%s\t%s\n", 
+                printf ("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\n",
                     bed.chrom.c_str(), start, end, 
                     bed.name.c_str(), bed.score.c_str());
             }
             else if (this->bedType == 6) {
-                printf ("%s\t%d\t%d\t%s\t%s\t%s\n", 
+                printf ("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s\n",
                     bed.chrom.c_str(), start, end, bed.name.c_str(),
                     bed.score.c_str(), bed.strand.c_str());
             }
             else if (this->bedType > 6) {
-                printf ("%s\t%d\t%d\t%s\t%s\t%s", 
+                printf ("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s",
                     bed.chrom.c_str(), start, end, bed.name.c_str(),
                     bed.score.c_str(), bed.strand.c_str());
 
@@ -1229,7 +1232,7 @@ public:
         }
         // VCF
         else if (_isGff == false && _isVcf == true) {
-            printf ("%s\t%d", bed.chrom.c_str(), bed.start+1);
+            printf ("%s\t%" PRId_CHRPOS, bed.chrom.c_str(), bed.start+1);
             vector<uint16_t>::const_iterator othIt  = bed.other_idxs.begin();
             vector<uint16_t>::const_iterator othEnd = bed.other_idxs.end();
             for ( ; othIt != othEnd; ++othIt) {
@@ -1241,14 +1244,14 @@ public:
         else if (_isGff == true) {
             // "GFF-8"
             if (this->bedType == 8) {
-                printf ("%s\t%s\t%s\t%d\t%d\t%s\t%s\t%s\n", 
+                printf ("%s\t%s\t%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s\n",
                     bed.chrom.c_str(), bed.fields[bed.other_idxs[0]].c_str(),
                     bed.name.c_str(), start+1, end,
                     bed.score.c_str(), bed.strand.c_str(),                                          bed.fields[bed.other_idxs[1]].c_str());
             }
             // "GFF-9"
             else if (this->bedType == 9) {
-                printf ("%s\t%s\t%s\t%d\t%d\t%s\t%s\t%s\t%s\n", 
+                printf ("%s\t%s\t%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s\t%s\n",
                     bed.chrom.c_str(), bed.fields[bed.other_idxs[0]].c_str(),
                     bed.name.c_str(), start+1, end,
                     bed.score.c_str(), bed.strand.c_str(),

--- a/src/utils/bedFilePE/bedFilePE.cpp
+++ b/src/utils/bedFilePE/bedFilePE.cpp
@@ -91,26 +91,31 @@ BedLineStatus BedFilePE::GetNextBedPE (BEDPE &bedpe, int &lineNum) {
 void BedFilePE::reportBedPETab(const BEDPE &a) {
 
     if (this->bedType == 6) {
-        printf("%s\t%ld\t%ld\t%s\t%ld\t%ld\t", a.chrom1.c_str(), a.start1, a.end1,
+        printf("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t",
+                                            a.chrom1.c_str(), a.start1, a.end1,
                                             a.chrom2.c_str(), a.start2, a.end2);
     }
     else if (this->bedType == 7) {
-        printf("%s\t%ld\t%ld\t%s\t%ld\t%ld\t%s\t", a.chrom1.c_str(), a.start1, a.end1,
+        printf("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t",
+                                            a.chrom1.c_str(), a.start1, a.end1,
                                             a.chrom2.c_str(), a.start2, a.end2,
                                             a.name.c_str());
     }
     else if (this->bedType == 8) {
-        printf("%s\t%ld\t%ld\t%s\t%ld\t%ld\t%s\t%s\t", a.chrom1.c_str(), a.start1, a.end1,
+        printf("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t",
+                                            a.chrom1.c_str(), a.start1, a.end1,
                                             a.chrom2.c_str(), a.start2, a.end2,
                                             a.name.c_str(), a.score.c_str());
     }
     else if (this->bedType == 10) {
-        printf("%s\t%ld\t%ld\t%s\t%ld\t%ld\t%s\t%s\t%s\t%s\t", a.chrom1.c_str(), a.start1, a.end1,
+        printf("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s\t%s\t",
+                                            a.chrom1.c_str(), a.start1, a.end1,
                                             a.chrom2.c_str(), a.start2, a.end2,
                                             a.name.c_str(), a.score.c_str(), a.strand1.c_str(), a.strand2.c_str());
     }
     else if (this->bedType > 10) {
-        printf("%s\t%ld\t%ld\t%s\t%ld\t%ld\t%s\t%s\t%s\t%s", a.chrom1.c_str(), a.start1, a.end1,
+        printf("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s\t%s",
+                                            a.chrom1.c_str(), a.start1, a.end1,
                                             a.chrom2.c_str(), a.start2, a.end2,
                                             a.name.c_str(), a.score.c_str(), a.strand1.c_str(), a.strand2.c_str());
         vector<uint16_t>::const_iterator othIt  = a.other_idxs.begin();
@@ -133,26 +138,31 @@ void BedFilePE::reportBedPETab(const BEDPE &a) {
 void BedFilePE::reportBedPENewLine(const BEDPE &a) {
 
     if (this->bedType == 6) {
-        printf("%s\t%ld\t%ld\t%s\t%ld\t%ld\n", a.chrom1.c_str(), a.start1, a.end1,
+        printf("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\n",
+                                            a.chrom1.c_str(), a.start1, a.end1,
                                             a.chrom2.c_str(), a.start2, a.end2);
     }
     else if (this->bedType == 7) {
-        printf("%s\t%ld\t%ld\t%s\t%ld\t%ld\t%s\n", a.chrom1.c_str(), a.start1, a.end1,
+        printf("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\n",
+                                            a.chrom1.c_str(), a.start1, a.end1,
                                             a.chrom2.c_str(), a.start2, a.end2,
                                             a.name.c_str());
     }
     else if (this->bedType == 8) {
-        printf("%s\t%ld\t%ld\t%s\t%ld\t%ld\t%s\t%s\n", a.chrom1.c_str(), a.start1, a.end1,
+        printf("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\n",
+                                            a.chrom1.c_str(), a.start1, a.end1,
                                             a.chrom2.c_str(), a.start2, a.end2,
                                             a.name.c_str(), a.score.c_str());
     }
     else if (this->bedType == 10) {
-        printf("%s\t%ld\t%ld\t%s\t%ld\t%ld\t%s\t%s\t%s\t%s\n", a.chrom1.c_str(), a.start1, a.end1,
+        printf("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s\t%s\n",
+                                            a.chrom1.c_str(), a.start1, a.end1,
                                             a.chrom2.c_str(), a.start2, a.end2,
                                             a.name.c_str(), a.score.c_str(), a.strand1.c_str(), a.strand2.c_str());
     }
     else if (this->bedType > 10) {
-        printf("%s\t%ld\t%ld\t%s\t%ld\t%ld\t%s\t%s\t%s\t%s", a.chrom1.c_str(), a.start1, a.end1,
+        printf("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t%s\t%s",
+                                            a.chrom1.c_str(), a.start1, a.end1,
                                             a.chrom2.c_str(), a.start2, a.end2,
                                             a.name.c_str(), a.score.c_str(), a.strand1.c_str(), a.strand2.c_str());
         vector<uint16_t>::const_iterator othIt  = a.other_idxs.begin();


### PR DESCRIPTION
* Updates the `-I` entry in the makefile and the HTSlib include lines to `#include <htslib/sam.h>` etc. This is how HTSlib's headers are set up to be used, and doing this will facilitate bedtools using an external HTSlib should that become practical in future.

* Adds a `PRId_CHRPOS` macro based on `PRId64` for use when printfing `CHRPOS` values, preventing a bunch of warnings.

   At present eleven header files definite the `CHRPOS` typedef and I've added `PRId_CHRPOS` to two of them. All these should probably be centralised in _BedtoolsTypes.h_ at some point.

* Some other minor warnings coming from header files.
