### PR TITLE
bedtools2: add stdlib.h include to make it compile on xcode 7 and 8

### DIFF
--- a/src/utils/BamTools/include/BamAlignment.hpp
+++ b/src/utils/BamTools/include/BamAlignment.hpp
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <memory>
 #include <cstring>
+#include <stdlib.h>
 namespace BamTools {
 	const static char cigar_ops_as_chars[] = { 'M', 'I', 'D', 'N', 'S', 'H', 'P', '=', 'X', 'B' };
 	static inline std::string _mkstr(const uint8_t* what) { return std::string((const char*)what + 1); }

--- a/src/utils/BamTools/include/SamHeader.hpp
+++ b/src/utils/BamTools/include/SamHeader.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <string.h>
 #include <api/BamAux.h>
+#include <stdlib.h>
 namespace BamTools {
 
 	typedef std::vector<RefData> RefVector;


### PR DESCRIPTION
Hi! While testing the macports port for v2.28.0, I noticed this version of bedtools does not build on older versions of xcode (7 and 8) without this include. Thanks.

-- Arjan
