### PR TITLE
Add " -D__STDC_FORMAT_MACRO" to CXXFLAGS to fix compiling bedtools.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ export SRC_DIR	= src
 export UTIL_DIR	= src/utils
 export CXX		= g++
 ifeq ($(DEBUG),1)
-export CXXFLAGS = -Wconversion -Wall -Wextra -DDEBUG -D_DEBUG -g -O0 -D_FILE_OFFSET_BITS=64 -DWITH_HTS_CB_API $(INCLUDES)
+export CXXFLAGS = -Wconversion -Wall -Wextra -DDEBUG -D_DEBUG -g -O0 -D_FILE_OFFSET_BITS=64 -DWITH_HTS_CB_API -D__STDC_FORMAT_MACROS $(INCLUDES)
 else
-export CXXFLAGS = -g -Wall -O2 -D_FILE_OFFSET_BITS=64 -DWITH_HTS_CB_API $(INCLUDES)
+export CXXFLAGS = -g -Wall -O2 -D_FILE_OFFSET_BITS=64 -DWITH_HTS_CB_API -D__STDC_FORMAT_MACROS $(INCLUDES)
 endif
 
 # If the user has specified to do so, tell the compile to use rand() (instead of mt19937).


### PR DESCRIPTION
Add " -D__STDC_FORMAT_MACRO" to CXXFLAGS to fix compiling bedtools.
This fixes the following problems during compilation:

      * compiling chromsweep.cpp
    In file included from bedFile.cpp:12:0:
    bedFile.h: In member function ‘void BedFile::reportBedTab(const T&)’:
    bedFile.h:47:21: error: expected ‘)’ before ‘PRId64’
     #define PRId_CHRPOS PRId64
                         ^
    bedFile.h:942:33: note: in expansion of macro ‘PRId_CHRPOS’
                     printf ("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t", bed.chrom.c_str(), start, end);
                                     ^~~~~~~~~~~
    bedFile.h:47:21: error: expected ‘)’ before ‘PRId64’
     #define PRId_CHRPOS PRId64
                         ^
    bedFile.h:945:33: note: in expansion of macro ‘PRId_CHRPOS’
                     printf ("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t",
                                     ^~~~~~~~~~~
    bedFile.h:47:21: error: expected ‘)’ before ‘PRId64’
     #define PRId_CHRPOS PRId64
                         ^
    bedFile.h:949:33: note: in expansion of macro ‘PRId_CHRPOS’
                     printf ("%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS "\t%s\t%s\t",
                                     ^~~~~~~~~~~