### PR TITLE
Define __STDC_FORMAT_MACROS to fix build on old compiler environments

### DIFF
--- a/src/randomBed/randomBed.h
+++ b/src/randomBed/randomBed.h
@@ -9,6 +9,7 @@
 
   Licenced under the GNU General Public License 2.0 license.
 ******************************************************************************/
+#include "BedtoolsTypes.h"
 #include "GenomeFile.h"
 
 #include <vector>
@@ -17,7 +18,6 @@
 #include <map>
 #include <cstdlib>
 #include <ctime>
-#include <inttypes.h>
 #include <sys/time.h>
 #include <unistd.h>
 #include <sys/types.h>
@@ -25,10 +25,6 @@
 using namespace std;
 
 const int MAX_TRIES = 1000000;
-
-typedef int64_t CHRPOS;
-
-#define PRId_CHRPOS PRId64
 
 //************************************************
 // Class methods and elements

--- a/src/split/splitBed.cpp
+++ b/src/split/splitBed.cpp
@@ -11,7 +11,6 @@
 #include <climits>
 #include <sstream>
 #include <iomanip>
-#include <inttypes.h>
 #include <getopt.h>
 #include "lineFileUtilities.h"
 #include "version.h"

--- a/src/utils/BinTree/BinTree.h
+++ b/src/utils/BinTree/BinTree.h
@@ -8,7 +8,8 @@
 #ifndef BINTREE_H_
 #define BINTREE_H_
 
-#include <inttypes.h>
+#include "BedtoolsTypes.h"
+
 #include <stdint.h>
 #include <string>
 #include <set>

--- a/src/utils/bedFile/bedFile.h
+++ b/src/utils/bedFile/bedFile.h
@@ -13,6 +13,7 @@
 #define BEDFILE_H
 
 // "local" includes
+#include "BedtoolsTypes.h"
 #include "gzstream.h"
 #include "lineFileUtilities.h"
 #include "fileType.h"
@@ -27,7 +28,6 @@
 #include <sstream>
 #include <cstring>
 #include <algorithm>
-#include <inttypes.h>
 #include <limits.h>
 #include <stdint.h>
 #include <cstdio>
@@ -38,13 +38,10 @@ using namespace std;
 //*************************************************
 // Data type tydedef
 //*************************************************
-typedef int64_t CHRPOS;
 typedef uint16_t BINLEVEL;
 typedef uint32_t BIN;
 typedef uint16_t USHORT;
 typedef uint32_t UINT;
-
-#define PRId_CHRPOS PRId64
 
 //*************************************************
 // Genome binning constants

--- a/src/utils/general/BedtoolsTypes.h
+++ b/src/utils/general/BedtoolsTypes.h
@@ -8,9 +8,11 @@
 #ifndef BEDTOOLSTYPES_H_
 #define BEDTOOLSTYPES_H_
 
-using namespace std;
+// Some old environments require this even though standard C++ doesn't
+#define __STDC_FORMAT_MACROS
 
 #include <stdint.h>
+#include <inttypes.h>
 #include <climits>
 #include <string>
 #include <cstdlib>
@@ -25,9 +27,11 @@ using namespace std;
 #include <set>
 #include <map>
 
+using namespace std;
 
 typedef int64_t CHRPOS;
 
+#define PRId_CHRPOS PRId64
 
 
 #endif /* BEDTOOLSTYPES_H_ */


### PR DESCRIPTION
Fix the `__STDC_FORMAT_MACROS` thing by moving `PRId_CHRPOS` to BedtoolsTypes.h and including that header in the two headers that previously defined `PRId_CHRPOS`. As an alternative to #713 that centralises this mess in one place under the covers — #713's approach of adding it to CXXFLAGS in the Makefile is a little fragile if people happen to be overriding CXXFLAGS themselves.

Apologies for the oversight and the resulting inconvenience… 😞 