### PR TITLE
Fix issue 767 and 768

### DIFF
--- a/src/slopBed/slopBed.cpp
+++ b/src/slopBed/slopBed.cpp
@@ -78,6 +78,11 @@ void BedSlop::AddSlop(BED &bed) {
     // strand and the user cares about strandedness.
     CHRPOS chromSize = (CHRPOS)_genome->getChromSize(bed.chrom);
 
+	if(chromSize < 0) {
+		cerr << "* Input error: Chromosome " << bed.chrom << " doesn't present in the .genome file. *" << endl;
+		exit(1);
+	}
+
 	bool should_swap = _forceStrand && bed.strand == "-";
 	long left_slop = should_swap ? (long)_rightSlop : (long)_leftSlop;
 	long right_slop = should_swap ? (long)_leftSlop : (long)_rightSlop;

--- a/src/utils/Contexts/ContextBase.cpp
+++ b/src/utils/Contexts/ContextBase.cpp
@@ -649,7 +649,7 @@ FileRecordMgr *ContextBase::getNewFRM(const string &filename, int fileIdx) {
 bool ContextBase::parseIoBufSize(string bufStr)
 {
 	char lastChar = bufStr[bufStr.size()-1];
-	int multiplier = 1;
+	size_t multiplier = 1;
 	if (!isdigit(lastChar)) {
 		switch (lastChar) {
 		case 'K':
@@ -675,7 +675,7 @@ bool ContextBase::parseIoBufSize(string bufStr)
 		_errorMsg = "\n***** ERROR: argument passed to -iobuf is not numeric. *****";
 		return false;
 	}
-	_ioBufSize = (int)str2chrPos(bufStr) * multiplier;
+	_ioBufSize = (size_t)str2chrPos(bufStr) * multiplier;
 	if (_ioBufSize < MIN_ALLOWED_BUF_SIZE) {
 		_errorMsg = "\n***** ERROR: specified buffer size is too small. *****";
 		return false;

--- a/src/utils/Contexts/ContextBase.h
+++ b/src/utils/Contexts/ContextBase.h
@@ -181,7 +181,7 @@ protected:
     bool _obeySplits;
     bool _uncompressedBam;
     bool _useBufferedOutput;
-    int _ioBufSize;
+    size_t _ioBufSize;
 
 	bool _anyHit;
     bool _noHit;

--- a/src/utils/FileRecordTools/FileReaders/BufferedStreamMgr.cpp
+++ b/src/utils/FileRecordTools/FileReaders/BufferedStreamMgr.cpp
@@ -56,7 +56,7 @@ bool BufferedStreamMgr::init()
 		_useBufSize = GZIP_LINE_BUF_SIZE;
 	}
 
-	size_t trueBufSize = max(_useBufSize, (int)_currScanBuffer.size());
+	size_t trueBufSize = max(_useBufSize, _currScanBuffer.size());
 	_useBufSize = (int)trueBufSize;
 	_mainBuf = new bufType[_useBufSize +1];
 	memset(_mainBuf, 0, _useBufSize +1);

--- a/src/utils/FileRecordTools/FileReaders/BufferedStreamMgr.h
+++ b/src/utils/FileRecordTools/FileReaders/BufferedStreamMgr.h
@@ -26,7 +26,7 @@ public:
 	bool getLine(string &line);
 	BamTools::BamReader *getBamReader() { return _inputStreamMgr->getBamReader(); }
 	static const int DEFAULT_MAIN_BUF_READ_SIZE = 1023;
-	void setIoBufSize(int val) { _useBufSize = val; }
+	void setIoBufSize(size_t val) { _useBufSize = val; }
 private:
 	InputStreamMgr *_inputStreamMgr;
 	typedef unsigned char bufType;
@@ -38,7 +38,7 @@ private:
 	int _mainBufCurrStartPos;
 	int _mainBufCurrLen;
 	bool _eof;
-	int _useBufSize;
+	size_t _useBufSize;
 	bool _streamFinished;
 	string _currScanBuffer;
 

--- a/test/intersect/new_test-intersect.sh
+++ b/test/intersect/new_test-intersect.sh
@@ -941,7 +941,6 @@ check exp obs
 rm exp obs
 [[ $FAILURES -eq 0 ]] || exit 1;
 
-
 ###########################################################
 #  Test intersect with bam has no text header
 ############################################################
@@ -956,6 +955,16 @@ GA5:3:49:1480:1116#0	16	dummy_chr	11913868	37	76M	*	0	0	GGGAGGAGGCCAGGACTTCAGGGA
 GA5:3:61:213:1812#0	16	dummy_chr	13030396	37	76M	*	0	0	GGTCCGGCGGGGTCGGACTGGACCAGCTGTTGGGCTTTGTTTGCTCTTTTTACGAATTGAAAAACTGAAGCCAGGA	/=81,5948=485=4,),1;;7:87:6=;;@@AB=C8A@@BAB=>5>BBBB>BBAAA9ABA@B4B;BBBBBBBBCB	XT:A:U	NM:i:1	X0:i:1	X1:i:0	XM:i:1	XO:i:0	XG:i:0	MD:Z:0T75
 GA5:3:116:1581:552#0	16	dummy_chr	15055984	37	76M	*	0	0	AGAAAGCCTAAGGTCAGGGTGCCAGCAGGTTTGGTGTCTGGTGAGGTACCCATCTCTGCTTCTAAGGCAGAGCCTT	48887429,3=;98<8<8@;<=?8@??98@@@<=AA>@@?B?A@@BA6BA@=@BABBB???B@BBBBBABBCBB?B	XT:A:U	NM:i:0	X0:i:1	X1:i:0	XM:i:0	XO:i:0	XG:i:0	MD:Z:76" > exp
 $BT intersect -a notexthdr.bam -b notexthdr.bam | samtools view > obs
+check exp obs
+rm exp obs
+[[ $FAILURES -eq 0 ]] || exit 1;
+
+###########################################################
+#  Test intersect with 2G io buffer, shouldn't overflow
+############################################################
+echo -e "    intersect.new.t77...\c"
+echo -n "" > exp
+$BT intersect -iobuf 2G -ubam -S -u -sorted -b a.bam -a a.bed >obs
 check exp obs
 rm exp obs
 [[ $FAILURES -eq 0 ]] || exit 1;


### PR DESCRIPTION
For issue #767, the only thing is int overflow, change all size to use size_t, which suppose to be the right type for memory size.

For issue #768, It seems the original logic is overly complicated I've refactor them. And for chrom doesn't present, it treat the gnome size is unlimited. (Not sure if this is expected, but for v0.2.6 it behaves in this way).