### PR TITLE
Fix issue 816: annotate -names on an empty input file

### DIFF
--- a/src/annotateBed/annotateBed.cpp
+++ b/src/annotateBed/annotateBed.cpp
@@ -55,9 +55,10 @@ void BedAnnotate::CloseAnnoFiles() {
 
 void BedAnnotate::PrintHeader() {
     // print a hash to indicate header and then write a tab
-    // for each field in the main file.
+    // for each field in the main file (less one, as the first
+    // label printed below is prefixed by a tab)
     printf("#");
-    for (size_t i = 0; i < _bed->bedType -1; ++i)
+    for (size_t i = 1; i < _bed->bedType; ++i)
         printf("\t");
 
     // now print the label for each file.


### PR DESCRIPTION
Avoid looping SIZE_MAX times when `_bed->bedType` is 0; we can't just subtract 1 from an unsigned variable with value 0.

This still prints an extra tab when bedType is 0 as the code that prints the labels prefixes the first one with a tab, but as this is a degenerate case of an empty file it's not worth changing.

Happily, there are no other instances of `bedType - 1` in the code at present.