### PR TITLE
Update coverage docs in advanced-usage.rst

### DIFF
--- a/docs/content/advanced-usage.rst
+++ b/docs/content/advanced-usage.rst
@@ -55,7 +55,7 @@ it to be counted, you can first use intersectBed with the "-f 1.0" option.
 .. code-block:: bash
 
   bedtools intersect -a features.bed -b windows.bed -f 1.0 | \
-  bedtools coverage -a - -b windows.bed \
+  bedtools coverage -a windows.bed -b - \
   > windows.bed.coverage
 
 
@@ -68,7 +68,7 @@ from the BAM data by using ``bamtobed``.
 .. code-block:: bash
 
   bedtools bamtobed -i reads.bam | \
-  bedtools coverage -a - -b exons.bed \
+  bedtools coverage -a exons.bed -b - \
   > exons.bed.coverage
   
 


### PR DESCRIPTION
I have updated here the first two `bedtools coverage` examples to reflect changes in the ordering of arguments for that command.

As I do not have experience with the `-abam` option, I did not change the command at https://github.com/arq5x/bedtools2/commit/91628aac2b171f54cacfc38fbe6da0f508450624#diff-0146c5f9d1549f0728ce970bf905d2d5R80 , but I suspect that may need be updating as well.