### PR TITLE
Allow cram reference passed with parameter

### DIFF
--- a/src/bedtools.cpp
+++ b/src/bedtools.cpp
@@ -87,10 +87,28 @@ int windowmaker_main(int argc, char* argv[]); //
 int bedtools_help(void);
 int bedtools_faq(void);
 
+const char* cram_reference = NULL;
+
+int parse_global_args(int argc, char** argv) {
+	for(int i = 1; i < argc - 1; i ++) {
+		string this_arg = argv[i];
+		if (this_arg == "--cram-ref") {
+			cram_reference = argv[i + 1];
+			for(int j = i + 2; j < argc; j ++) {
+				argv[j - 2] = argv[j];
+			}
+			i --;
+			argc -= 2;
+		}
+	}
+	return argc;
+}
+
 
 
 int main(int argc, char *argv[])
 {
+	argc = parse_global_args(argc, argv);
     // make sure the user at least entered a sub_command
     if (argc < 2) return bedtools_help();
 
@@ -273,6 +291,10 @@ int bedtools_help(void)
     cout  << "    expand        "  << "Replicate lines based on lists of values in columns.\n";
     cout  << "    split         "  << "Split a file into multiple files with equal records or base pairs.\n"; 
     cout  << "    summary       "  << "Statistical summary of intervals in a file.\n"; 
+
+	cout << endl;
+	cout << "[ General Parameters ]" << endl;
+	cout << "     --cram-ref    " << "Reference used by a CRAM input" << endl;
 
     cout  << endl;
     cout  << "[ General help ]" << endl;

--- a/src/utils/BamTools/include/BamReader.hpp
+++ b/src/utils/BamTools/include/BamReader.hpp
@@ -11,6 +11,7 @@
 #include <queue>
 #include <istream>
 
+extern const char* cram_reference;
 namespace BamTools {
 #ifdef WITH_HTS_CB_API
 	struct stream_data_t {
@@ -178,7 +179,7 @@ namespace BamTools {
 
 			if(fp->format.format == htsExactFormat::cram)
 			{
-				char* ref_file = getenv("CRAM_REFERENCE");
+				const char* ref_file = cram_reference ? cram_reference : getenv("CRAM_REFERENCE");
 				if(NULL == ref_file || hts_set_fai_filename(fp, ref_file) == -1)
 				{
 					// If we are not able to load a reference 

--- a/src/utils/BamTools/include/BamWriter.hpp
+++ b/src/utils/BamTools/include/BamWriter.hpp
@@ -5,6 +5,9 @@
 #include <htslib/sam.h>
 #include <SamHeader.hpp>
 #include <BamAlignment.hpp>
+
+extern const char* cram_reference;
+
 namespace BamTools {
 	class BamWriter {
 		samFile* _fp;
@@ -17,7 +20,7 @@ namespace BamTools {
 
 		bool Open(const std::string& filename, const std::string& samHeaderText, const RefVector& referenceSequences, refs_t* reference)
 		{
-			const char* ref_file = getenv("CRAM_REFERENCE");
+			const char* ref_file = cram_reference ? cram_reference : getenv("CRAM_REFERENCE");
 
 			_fp = sam_open(filename.empty() || filename == "stdout" ? "-" : filename.c_str(), ref_file ? "wc" : "wb");
 			if(_fp == nullptr) return false;


### PR DESCRIPTION
Closes issue #846 

Since all bedtools subcommand parse the parameter independently, a global setting is required for things like CRAM refs. This change allows global settings (particularly CRAM_REFERENCE) to be configured with parameters.  