### PR TITLE
Handle q==0.0 case in kt_fisher_exact()

### DIFF
--- a/src/fisher/kfunc.cpp
+++ b/src/fisher/kfunc.cpp
@@ -239,7 +239,11 @@ double kt_fisher_exact(long long n11, long long n12, long long n21, long long n2
     *two = left + right;
     if (*two > 1.) *two = 1.;
     // adjust left and right
-    if (labs((long) (i - n11)) < labs((long) (j - n11))) right = 1. - left + q;
+    if (q == 0.) {
+        if (n11 + n22 < n12 + n21) right = 1.;
+        else left = 1.;
+    }
+    else if (labs((long) (i - n11)) < labs((long) (j - n11))) right = 1. - left + q;
     else left = 1.0 - right + q;
     *_left = left; *_right = right;
     return q;


### PR DESCRIPTION
When some of `kt_fisher_exact()`'s input arguments are very large, `hypergeo(…)` is dominated by the subtracted `lbinom()` so returns `exp(≤ -750)`, which underflows, hence `hypergeo()` returns 0.0.

When `q` is 0.0, `kt_fisher_exact()`'s loops never execute and which of `i` and `j` is closer to `n11` is indeterminate. Hence we handle the adjustment of `left`/`right` separately in this case.

The `n11 + n22 < n12 + n21` test in that additional handling is motivated by [this description of left/right](https://www.langsrud.com/fisher.htm#INTRO) and agrees with the implementations in R and SciPy for various test cases, but this function's code is rather opaque so who really knows…

Hopefully fixes #343 and #855.