### PR TITLE
Add command-line options for ignoring local deletions

### DIFF
--- a/src/genomeCoverageBed/genomeCoverageBed.cpp
+++ b/src/genomeCoverageBed/genomeCoverageBed.cpp
@@ -17,7 +17,7 @@ BedGenomeCoverage::BedGenomeCoverage(string bedFile, string genomeFile,
                                      bool eachBase, bool startSites,
                                      bool bedGraph, bool bedGraphAll,
                                      int max, float scale,
-                                     bool bamInput, bool obeySplits,
+                                     bool bamInput, bool obeySplits, bool ignoreD,
                                      bool filterByStrand, string requestedStrand,
                                      bool only_5p_end, bool only_3p_end,
                                      bool pair_chip, bool haveSize, int fragmentSize, bool dUTP,
@@ -35,6 +35,7 @@ BedGenomeCoverage::BedGenomeCoverage(string bedFile, string genomeFile,
     _scale = scale;
     _bamInput = bamInput;
     _obeySplits = obeySplits;
+    _ignoreD = ignoreD;
     _filterByStrand = filterByStrand;
     _requestedStrand = requestedStrand;
     _only_3p_end = only_3p_end;
@@ -345,14 +346,9 @@ void BedGenomeCoverage::CoverageBam(string bamFile) {
         // add coverage accordingly.
         if (!_only_5p_end && !_only_3p_end) {
             bedVector bedBlocks;
-            // we always want to split blocks when a D CIGAR op is found.
+            // if the user invokes -ignoreD, we want to ignore D ops (breakOnDeletionOps == !_ignoreD).
             // if the user invokes -split, we want to also split on N ops.
-            if (_obeySplits) { // "D" true, "N" true
-                GetBamBlocks(bam, refs.at(bam.RefID).RefName, bedBlocks, true, true);
-            }
-            else { // "D" true, "N" false
-                GetBamBlocks(bam, refs.at(bam.RefID).RefName, bedBlocks, true, false);
-            }
+            GetBamBlocks(bam, refs.at(bam.RefID).RefName, bedBlocks, !_ignoreD, _obeySplits);
             AddBlockedCoverage(bedBlocks);
         }
         else if (_only_5p_end) {

--- a/src/genomeCoverageBed/genomeCoverageBed.h
+++ b/src/genomeCoverageBed/genomeCoverageBed.h
@@ -45,7 +45,7 @@ public:
                       bool eachBase, bool startSites,
                       bool bedGraph, bool bedGraphAll,
                       int max, float scale,
-                      bool bamInput, bool obeySplits,
+                      bool bamInput, bool obeySplits, bool ignoreD,
                       bool filterByStrand, string requestedStrand,
                       bool only_5p_end, bool only_3p_end,
                       bool pair_chip,bool haveSize, int fragmentSize, bool dUTP,
@@ -69,6 +69,7 @@ private:
     int _max;
     float _scale;
     bool _obeySplits;
+    bool _ignoreD;
     bool _filterByStrand;
     bool _only_5p_end;
     bool _only_3p_end;

--- a/src/genomeCoverageBed/genomeCoverageMain.cpp
+++ b/src/genomeCoverageBed/genomeCoverageMain.cpp
@@ -45,6 +45,7 @@ int genomecoverage_main(int argc, char* argv[]) {
     bool eachBase = false;
     bool eachBaseZeroBased = false;
     bool obeySplits = false;
+    bool ignoreD = false;
     bool haveScale = false;
     bool filterByStrand = false;
     bool pair_chip = false;
@@ -125,6 +126,9 @@ int genomecoverage_main(int argc, char* argv[]) {
         }
         else if(PARAMETER_CHECK("-split", 6, parameterLength)) {
             obeySplits = true;
+        }
+        else if(PARAMETER_CHECK("-ignoreD", 8, parameterLength)) {
+            ignoreD = true;
         }
         else if(PARAMETER_CHECK("-strand", 7, parameterLength)) {
             if ((i+1) < argc) {
@@ -220,7 +224,7 @@ int genomecoverage_main(int argc, char* argv[]) {
     if (!showHelp) {
         BedGenomeCoverage *bc = new BedGenomeCoverage(bedFile, genomeFile, eachBase,
                                                       startSites, bedGraph, bedGraphAll,
-                                                      max, scale, bamInput, obeySplits,
+                                                      max, scale, bamInput, obeySplits, ignoreD,
                                                       filterByStrand, requestedStrand,
                                                       only_5p_end, only_3p_end,
                                                       pair_chip, haveSize, fragmentSize, dUTP,
@@ -269,6 +273,9 @@ void genomecoverage_help(void) {
     cerr << "\t\t\tto infer the blocks for computing coverage." << endl;
     cerr << "\t\t\tFor BED12 files, this uses the BlockCount, BlockStarts, and BlockEnds" << endl;
     cerr << "\t\t\tfields (i.e., columns 10,11,12)." << endl << endl;
+
+    cerr << "\t-ignoreD\t" << "Ignore local deletions (CIGAR \"D\" operations) in BAM entries" << endl;
+    cerr << "\t\t\twhen computing coverage." << endl << endl;
 
     cerr << "\t-strand\t\t" << "Calculate coverage of intervals from a specific strand." << endl;
     cerr << "\t\t\tWith BED files, requires at least 6 columns (strand is column 6). " << endl;


### PR DESCRIPTION
This adds a command-line option "-ignoreD" which will treat any Ds in the CIGAR string as being equivalent to M/X/=. In other words, coverage is calculated ignoring any local deletions.

The functionality to do this was already present in the code in [BlockedIntervals.cpp](https://github.com/arq5x/bedtools2/blob/67d5cd8f9ca10556688a8331a73cc8fc604191d1/src/utils/BlockedIntervals/BlockedIntervals.cpp#L42); this patch simply exposes that functionality to the command line.

For reference (including example SAM files), see issue #867.