### PR TITLE
Reset the zero size flag when reuse the bed record

### DIFF
--- a/src/utils/FileRecordTools/Records/Bed3Interval.cpp
+++ b/src/utils/FileRecordTools/Records/Bed3Interval.cpp
@@ -28,6 +28,7 @@ bool Bed3Interval::initFromFile(SingleLineDelimTextFileReader *fileReader)
 	fileReader->getField(2, _endPosStr);
 	_startPos = str2chrPos(_startPosStr);
 	_endPos = str2chrPos(_endPosStr);
+	_zeroLength = false;
 	return true;
 }
 


### PR DESCRIPTION
This address issue #859 