### PR TITLE
Use PRId_CHRPOS to printf CHRPOS values

### DIFF
--- a/src/utils/FileRecordTools/Records/Bed3Interval.cpp
+++ b/src/utils/FileRecordTools/Records/Bed3Interval.cpp
@@ -34,7 +34,7 @@ bool Bed3Interval::initFromFile(SingleLineDelimTextFileReader *fileReader)
 
 inline void print_record(const string& name, CHRPOS start, CHRPOS end, string& buf) {
 	static char buffer[1024];
-	snprintf(buffer, sizeof(buffer), "%s\t%ld\t%ld", name.c_str(), start, end);
+	snprintf(buffer, sizeof(buffer), "%s\t%" PRId_CHRPOS "\t%" PRId_CHRPOS, name.c_str(), start, end);
 	buf.append(buffer);
 }
 

--- a/src/utils/FileRecordTools/Records/Record.h
+++ b/src/utils/FileRecordTools/Records/Record.h
@@ -9,12 +9,10 @@
 #define RECORD_H_
 
 #include <string>
+#include "BedtoolsTypes.h"
 #include "FreeList.h"
 #include "string.h"
 #include "FileRecordTypeChecker.h"
-
-// Aaron use other typedef from bedFile.h
-typedef int64_t CHRPOS;
 
 
 using namespace std;


### PR DESCRIPTION
The recent PR #880's `print_record()` converted some iostreams code to use printf instead. It's printing `CHRPOS` values, and on macOS or with Clang this type is based on `long long` rather than `long`, so `%ld` produces warnings (and possibly failures on other platforms) and the code needs to use `PRId_CHRPOS` instead.

It needs an extra `#include` to use that, so it was easier to fix it in a PR than to describe what needed to be done to best make the `PRId_CHRPOS` definition available :smile: