### PR TITLE
Minor patches for easier porting and packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@
 # (c) 2009 Aaron Quinlan
 # ==========================
 
-SHELL := /bin/bash -e
+# Use sh for portability and avoid bash extensions in shell commands
+SHELL := /bin/sh -e
 
 VERSION_FILE=./src/utils/version/version_git.h
 RELEASED_VERSION_FILE=./src/utils/version/version_release.txt
@@ -21,7 +22,8 @@ OBJ_DIR	= obj
 BIN_DIR	= bin
 SRC_DIR	= src
 
-CXX     = g++
+# Default if not provided via the environment or make args
+CXX     ?= g++
 
 ifeq ($(DEBUG),1)
 BT_CPPFLAGS = -DDEBUG -D_DEBUG -D_FILE_OFFSET_BITS=64 -DWITH_HTS_CB_API $(INCLUDES)
@@ -41,7 +43,8 @@ endif
 BT_LDFLAGS =
 BT_LIBS    = -lz -lm -lbz2 -llzma -lpthread
 
-prefix ?= /usr/local
+# Default if not provided via the environment or make args
+PREFIX ?= /usr/local
 
 SUBDIRS = $(SRC_DIR)/annotateBed \
 		  $(SRC_DIR)/bamToBed \
@@ -197,9 +200,9 @@ $(BIN_DIR)/intersectBed: | $(BIN_DIR)
 .PHONY: all
 
 install: all
-	mkdir -p $(DESTDIR)$(prefix)/bin
+	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	for file in bin/* ; do \
-		cp -f $$file $(DESTDIR)$(prefix)/bin; \
+		cp -f $$file $(DESTDIR)$(PREFIX)/bin; \
 	done
 
 print_banner:

--- a/src/utils/htslib/Makefile
+++ b/src/utils/htslib/Makefile
@@ -22,20 +22,23 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-CC     = gcc
-AR     = ar
-RANLIB = ranlib
+# Defaults if not provided by the environment or make args
+CC     ?= gcc
+AR     ?= ar
+RANLIB ?= ranlib
 
 # Default libraries to link if configure is not used
 htslib_default_libs = -lz -lm -lbz2 -llzma
 
-CPPFLAGS =
+# Defaults if not provided by the environment or make args
+CPPFLAGS ?=
+CFLAGS   ?= -g -Wall -O2
+LDFLAGS  ?=
+
 # TODO: probably update cram code to make it compile cleanly with -Wc++-compat
 # For testing strict C99 support add -std=c99 -D_XOPEN_SOURCE=600
 #CFLAGS   = -g -Wall -O2 -pedantic -std=c99 -D_XOPEN_SOURCE=600 -D__FUNCTION__=__func__
-CFLAGS   = -g -Wall -O2
 EXTRA_CFLAGS_PIC = -fpic
-LDFLAGS  =
 LIBS     = $(htslib_default_libs)
 
 prefix      = /usr/local


### PR DESCRIPTION
Here are a few minor patches to ease porting to other platforms and package managers.

Many package managers provide standard variables like CXX, CXXFLAGS, PREFIX, etc., so using ?= in the  Makefiles makes patches unnecessary.

Also, /bin/sh on FreeBSD (based on Almquist shell) works fine with the existing code.

Thanks for the awesome tool!