### PR TITLE
Small Changes in Documentation Spacing

### DIFF
--- a/docs/content/quick-start.rst
+++ b/docs/content/quick-start.rst
@@ -33,7 +33,7 @@ Report those entries in A that overlap NO entries in B. Like "grep -v"
 
 .. code-block:: bash
 
-  bedtools intersect  -a reads.bed -b genes.bed -v
+  bedtools intersect -a reads.bed -b genes.bed -v
 
 
 Read BED A from STDIN. Useful for stringing together commands. For example, 

--- a/docs/content/tools/coverage.rst
+++ b/docs/content/tools/coverage.rst
@@ -182,7 +182,7 @@ been reported, a histogram summarizing the coverage among all features in A will
   chr1  30  40  a3  1  -
   chr1  100 200 a4  1  +
 
-  $ bedtools coverage  -a A.bed -b B.bed -hist
+  $ bedtools coverage -a A.bed -b B.bed -hist
   chr1  0   100 b1  1  +  0  70  100  0.7000000
   chr1  0   100 b1  1  +  1  30  100  0.3000000
   chr1  100 200 b2  1  -  1  100 100  1.0000000


### PR DESCRIPTION
I was looking through the bedtools quick start documentation:

https://bedtools.readthedocs.io/en/latest/content/quick-start.html

and I noticed that the second sample bedtools command had an extra space after the intersect command. The extra space has no effect on the command, but that extra space sort of annoyed me and I figured I would submit a pull request to remove it. This may very well be the most inconsequential pull request ever submitted. I completely understand if you like the sample command as it is formatted and feel free to delete this request.

I also grepped through the documentation and found one other time an extra space appeared as well. Thanks for your work on bedtools.

Matt