### PR TITLE
Building on Windows using MSYS2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,17 +3,46 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  build:
+  build-linux:
 
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v1
     - name: Compile and test Bedtools
-      run: make -j8 && make test
+      run: make -j $(nproc) && make test
     - name: Compile static binary
-      run:  make -j8 static
+      run:  make -j $(nproc) static
     - uses: actions/upload-artifact@v1
       with:
-          name: bedtools.static
+          name: bedtools.static-linux
           path: bin/bedtools.static
+
+  build-windows:
+
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+    - name: Set proper line endings in git
+      shell: powershell
+      run: git config --global core.autocrlf false
+    - uses: actions/checkout@v1
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: MSYS
+        install: gcc make python libbz2-devel liblzma-devel zlib-devel git diffutils
+    - name: CCompile and test Bedtools
+      run: make -j $(nproc) && make test
+    - name: Compile semi-static binary
+      run: make VERBOSE=1 -j $(nproc) static
+    - name: Copy msys-2.0.dll to bin
+      run: cp /usr/bin/msys-2.0.dll bin/
+    - uses: actions/upload-artifact@v2
+      with:
+          name: bedtools.static-windows
+          path: |
+            bin/bedtools.static
+            bin/msys-2.0.dll

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,12 @@ else
 BT_CXXFLAGS += -std=c++11
 endif
 
+# Support building on MSYS2
+UNAME := $(shell sh -c 'uname 2>/dev/null || echo Unknown')
+ifeq (MSYS_NT,$(findstring MSYS_NT,$(UNAME)))
+BT_CXXFLAGS += -D_GNU_SOURCE -D_DEFAULT_SOURCE
+endif
+
 BT_LDFLAGS =
 BT_LIBS    = -lz -lm -lbz2 -llzma -lpthread
 

--- a/docs/content/faq.rst
+++ b/docs/content/faq.rst
@@ -40,6 +40,20 @@ and on Fedora/Centos this would be:
     yum install zlib1g-dev
 
 --------------------------------------------------
+Is build on Windows possible?
+--------------------------------------------------
+Yes. Currently build on Windows could be done via `MSYS2 <https://www.msys2.org/>`_. You need to:
+- Install MSYS2
+- Open MSYS2 Bash shell
+- Install build dependencies via command
+.. code-block:: bash
+    pacman -S gcc make python libbz2-devel liblzma-devel zlib-devel git diffutils
+- Run ``make`` command.
+At the moment MSYS2 does not support fully static builds, so bedtools.static depends on file ``msys-2.0.dll``
+(could be found at ``C:\msys64\usr\bin\msys-2.0.dll`` if default install path is used). You need to distribute this file
+together with main executable.
+
+--------------------------------------------------
 Compiling with a specific zlib library
 --------------------------------------------------
 If you need to override the location of the zlib library used to compile bedtools, you can run `make` and specify the `LIBS` argument. For example:

--- a/test/fisher/test-fisher.sh
+++ b/test/fisher/test-fisher.sh
@@ -102,7 +102,7 @@ rm obs exp
 echo -e "    fisher.t5...\c"
 $BT fisher -b test.bed -a tumor.gff -g dm6.fai > exp
 DIR="${TMPDIR:-/tmp}/Users/mvandenb/src/genomic_features_bardin_lab/build/modencode/dm6/bed/"
-LONG_PATH="$DIR/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaS-\(phospho-S2\)_.bed"
+LONG_PATH="$DIR/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaS-phospho-S2_.bed"
 mkdir -p "$DIR"
 cp test.bed "$LONG_PATH"
 $BT fisher -b "$LONG_PATH" -a tumor.gff -g dm6.fai > obs


### PR DESCRIPTION
Added possibility to build Bedtools on Windows using MSYS2. Required changes:
* Modified Makefile to conditionally add `-D_GNU_SOURCE -D_DEFAULT_SOURCE` definitions on MSYS2.
* Changed one of test filenames to exclude filename symbols that are unsupported on Windows (actually only `\` is unsupported, so braces could be returned back if needed).
* Added GitHub Actions CI to build and test on MSYS2.
* Added FAQ record to document MSYS2 dependencies installation process.

I also checked that changes are not breaking build on macOS (and also prepared a branch to add macOS CI, can create a pull request if needed).