### PR TITLE
Tiny tweak to error message when bamToFastq doesn't get a bam file

### DIFF
--- a/src/bamToFastq/bamToFastqMain.cpp
+++ b/src/bamToFastq/bamToFastqMain.cpp
@@ -98,7 +98,7 @@ int bamtofastq_main(int argc, char* argv[]) {
 
     // make sure we have a BAM file
     if (!haveInBam) {
-      cerr << endl << "*****" << endl << "*****ERROR: Need -bam. " << endl << "*****" << endl;
+      cerr << endl << "*****" << endl << "*****ERROR: Need bam file (-i). " << endl << "*****" << endl;
       showHelp = true;
     }
     // make sure we have an end1 FASTQ file


### PR DESCRIPTION
Hi there, 

Noticed this tiny tiny thing when trying to use bamToFastq: when no bam file is provided (or its given as a positional arugment) the error message asks for the `-bam` argument... which doesn't exist (it's -i).

This commit might save someone else three seconds of their life (and let me say I made a tiny contribution to one of my favourite pieces of software!)