### PR TITLE
Fix an unexpected warning from makewindows

### DIFF
--- a/src/windowMaker/windowMaker.cpp
+++ b/src/windowMaker/windowMaker.cpp
@@ -50,7 +50,8 @@ void WindowMaker::MakeWindowsFromGenome(const string& genomeFileName) {
     vector<string> chromList = _genome->getChromList();
 
     // process each chrom in the genome
-    for (size_t c = 0; c < chromList.size(); ++c) {
+    // exclude the last chrom from NewGenomeFile, because it has an empty name and 0-length
+    for (size_t c = 0; c < chromList.size() - 1; ++c) {
         string chrom = chromList[c];
 
         BED bed(chrom,0,_genome->getChromSize(chrom),chrom,"","");


### PR DESCRIPTION
Fix an issue where makewindows with a genome option (-g) and a count option (-n)
will always raise a warning of a zero length interval, which is appended by
NewGenomeFile class

---

I have found that `bedtools makewindows` with genome (-g) and count (-n) options always raise a warning of a zero length interval.
For example,
```
$ bedtools makewindows -g <(echo -e "chromA\t8") -n 3
chromA  0       2
chromA  2       4
chromA  4       8
WARNING: Interval :0-0 is smaller than the number of windows requested. Skipping.
```

The warning does not affect the standard output results, but it is not related to user-defined inputs and seems to be confusing.

The warning is written at https://github.com/arq5x/bedtools2/blob/484c0d4f5f76859aab6973da16f66861bfd7089e/src/windowMaker/windowMaker.cpp#L107

Then, I noticed that a zero length chromosome was appended by NewGenomeFile class, but not ignored by WindowMaker class.
Although GenomeFile class does not append a zero length chromosome and seems to work, NewGenomeFile class provides the stdin feature (commit https://github.com/arq5x/bedtools2/commit/43ac847245b642ebb4980dd254d110aeb9cf585c and issue https://github.com/arq5x/bedtools2/issues/735), so I avoided reverting to GenomeFile class from NewGenomeFile class at https://github.com/arq5x/bedtools2/blob/484c0d4f5f76859aab6973da16f66861bfd7089e/src/windowMaker/windowMaker.cpp#L47

However, this fix relies on the order of the empty chromosome from the NewGenomeFile object, so it may be better to backport the stdin support to GenomeFile class for stability.
In addition, my English may be incorrect, so please feel free to edit my commit and comments.

Environment:
bedtools (v2.30.0 and the current master https://github.com/arq5x/bedtools2/commit/484c0d4f5f76859aab6973da16f66861bfd7089e)
Ubuntu 20.04.2
