### PR TITLE
Fix the long help parameter check in makewindows

### DIFF
--- a/src/windowMaker/windowMakerMain.cpp
+++ b/src/windowMaker/windowMakerMain.cpp
@@ -50,7 +50,7 @@ int windowmaker_main(int argc, char* argv[]) {
         int parameterLength = (int)strlen(argv[i]);
 
         if((PARAMETER_CHECK("-h", 2, parameterLength)) ||
-        (PARAMETER_CHECK("--help", 5, parameterLength))) {
+        (PARAMETER_CHECK("--help", 6, parameterLength))) {
             showHelp = true;
         }
     }


### PR DESCRIPTION
This fix is minor, but modifies the check of "--help" option.
Without this fix, the program outputs "ERROR: Unrecognized parameter" for "--help", which seems to be unintentional.