### PR TITLE
Modify the error message in loading a genome file

### DIFF
--- a/src/utils/GenomeFile/NewGenomeFile.cpp
+++ b/src/utils/GenomeFile/NewGenomeFile.cpp
@@ -56,7 +56,7 @@ void NewGenomeFile::loadGenomeFileIntoMap() {
 		_genomeFile = new ifstream(_genomeFileName.c_str(), ios::in);
 		if (!_genomeFile->good()) 
 		{
-			cerr << "Error: Can't open genome file" << _genomeFileName << "Exiting..." << endl;
+			cerr << "Error: Can't open genome file " << _genomeFileName << ". Exiting..." << endl;
 			exit(1);
 		}
 	}


### PR DESCRIPTION
This commit just improves the error message by inserting spaces around a genome file.