### PR TITLE
Add makewindows initial window/step feature

### DIFF
--- a/src/windowMaker/windowMaker.h
+++ b/src/windowMaker/windowMaker.h
@@ -38,7 +38,7 @@ public:
 
     // constructor
     WindowMaker(string &fileName, ID_METHOD id_method, INPUT_FILE_TYPE input_file_type, uint32_t count, bool reverse);
-    WindowMaker(string &fileName, ID_METHOD id_method, INPUT_FILE_TYPE input_file_type, uint32_t size, uint32_t step, bool reverse);
+    WindowMaker(string &fileName, ID_METHOD id_method, INPUT_FILE_TYPE input_file_type, uint32_t size, uint32_t step, uint32_t initialSize, uint32_t initialStep, bool reverse);
 
     // destructor
     ~WindowMaker(void);
@@ -53,6 +53,8 @@ private:
     bool _reverse; // should window numbering be reversed?
     WINDOW_METHOD _window_method;
     ID_METHOD _id_method;
+    uint32_t _initialSize;
+    uint32_t _initialStep;
 
     void MakeBEDWindow(const BED& interval);
 

--- a/test/makewindows/test-makewindows.sh
+++ b/test/makewindows/test-makewindows.sh
@@ -178,4 +178,90 @@ echo \
 $BT makewindows -b a.19bp.bed -n 10 -i srcwinnum 2> obs
 check obs exp
 rm obs exp
+
+###########################################################
+#  Test window + initial window size
+###########################################################
+echo -e "    makewindows.t10...\c"
+echo \
+"chr5	60000	62000	3
+chr5	62000	66000	2
+chr5	66000	70000	1
+chr5	73000	75000	5
+chr5	75000	79000	4
+chr5	79000	83000	3
+chr5	83000	87000	2
+chr5	87000	90000	1
+chr5	100000	101000	1" > exp
+$BT makewindows -b input.bed -w 4000 -iw 2000 -i winnum -reverse > obs
+check obs exp
+rm obs exp
+
+###########################################################
+#  Test window + step + initial step size
+###########################################################
+echo -e "    makewindows.t11...\c"
+echo \
+"chr5	60000	64000	3
+chr5	62000	66000	2
+chr5	66000	70000	1
+chr5	73000	77000	5
+chr5	75000	79000	4
+chr5	79000	83000	3
+chr5	83000	87000	2
+chr5	87000	90000	1
+chr5	100000	101000	1" > exp
+$BT makewindows -b input.bed -w 4000 -s 4000 -is 2000 -i winnum -reverse > obs
+check obs exp
+rm obs exp
+
+###########################################################
+#  Test window + initial window + step + initial step size
+###########################################################
+echo -e "    makewindows.t12...\c"
+echo \
+"chr5	60000	62000	3
+chr5	63000	67000	2
+chr5	68000	70000	1
+chr5	73000	75000	4
+chr5	76000	80000	3
+chr5	81000	85000	2
+chr5	86000	90000	1
+chr5	100000	101000	1" > exp
+$BT makewindows -b input.bed -w 4000 -iw 2000 -s 5000 -is 3000 -i winnum -reverse > obs
+check obs exp
+rm obs exp
+
+###########################################################
+#  Test window + initial window + step + initial step (forward numbering)
+###########################################################
+echo -e "    makewindows.t13...\c"
+echo \
+"chr5	60000	62000	1
+chr5	63000	67000	2
+chr5	68000	70000	3
+chr5	73000	75000	1
+chr5	76000	80000	2
+chr5	81000	85000	3
+chr5	86000	90000	4
+chr5	100000	101000	1" > exp
+$BT makewindows -b input.bed -w 4000 -iw 2000 -s 5000 -is 3000 -i winnum > obs
+check obs exp
+rm obs exp
+
+###########################################################
+#  Test window + initial window + step + initial step (large initial sizes)
+###########################################################
+echo -e "    makewindows.t14...\c"
+echo \
+"chr5	60000	68000	1
+chr5	73000	81000	4
+chr5	83000	85000	3
+chr5	86000	88000	2
+chr5	89000	90000	1
+chr5	100000	101000	1" > exp
+$BT makewindows -b input.bed -w 2000 -iw 8000 -s 3000 -is 10000 -i winnum -reverse > obs
+check obs exp
+rm obs exp
+
 [[ $FAILURES -eq 0 ]] || exit 1;


### PR DESCRIPTION
Add a feature to makewindows that the initial window size and the initial step size can be specified.

I need to get tiling windows representing rounded coordinates at some digits.
That is, rounded coordinates at a digit are the boundaries of target windows.
For example:
```
chr1     0   500
chr1   500  1500
chr1  1500  2500
...
```

Currently, this kind of windows may be obtained by `bedtools makewindows`, `bedtools shift`, concatenate short intervals for each chromosome, and `bedtools sort`. However, the target windows can be obtained by only `bedtools makewindows` with some modifications, and it will be efficient (sorry, but I have not benchmarked).

In this pull request, I introduced "initial window size" (-iw) option and "initial step size" (-is) option. Using the options, you can use `bedtools makewindows` as follows:
```
$ bedtools makewindows -g <(echo -e "chromA\t3900\nchromB\t2200") -w 1000 -iw 500 -i srcwinnum -reverse
chromA  0       500     chromA_5
chromA  500     1500    chromA_4
chromA  1500    2500    chromA_3
chromA  2500    3500    chromA_2
chromA  3500    3900    chromA_1
chromB  0       500     chromB_3
chromB  500     1500    chromB_2
chromB  1500    2200    chromB_1
```

```
$ bedtools makewindows -g <(echo -e "chromA\t3900\nchromB\t2200") -w 20 -iw 10 -s 1000 -is 990 -i srcwinnum -r
everse
chromA  0       10      chromA_4
chromA  990     1010    chromA_3
chromA  1990    2010    chromA_2
chromA  2990    3010    chromA_1
chromB  0       10      chromB_3
chromB  990     1010    chromB_2
chromB  1990    2010    chromB_1
```

I'd like to share the changes.
Please feel free to edit my commit and comments.