### PR TITLE
Ignore Windows-style line termination in genome files

### DIFF
--- a/src/utils/GenomeFile/NewGenomeFile.cpp
+++ b/src/utils/GenomeFile/NewGenomeFile.cpp
@@ -67,6 +67,7 @@ void NewGenomeFile::loadGenomeFileIntoMap() {
 	_genomeLength = 0;
 	string chrName;
 	while (getline(*_genomeFile, line)) {
+		trimNewlines(line);
 		chrSize = 0;
 		chrName.clear();
 		int numFields = fieldTokens.tokenize(line.c_str());

--- a/src/utils/general/ParseTools.cpp
+++ b/src/utils/general/ParseTools.cpp
@@ -33,6 +33,12 @@ bool isInteger(const string &str) {
 	return hasDigits;
 }
 
+void trimNewlines(string& str) {
+	size_t len = str.length();
+	while (len > 0 && (str[len-1] == '\n' || str[len-1] == '\r'))
+		len--;
+	str.resize(len);
+}
 
 
 CHRPOS str2chrPos(const string &str) {

--- a/src/utils/general/ParseTools.h
+++ b/src/utils/general/ParseTools.h
@@ -24,6 +24,8 @@ typedef int64_t CHRPOS;
 bool isNumeric(const string &str);
 bool isInteger(const string &str);
 
+void trimNewlines(string& str);
+
 //This method is a faster version of atoi, but is limited to a maximum of
 //9 digit numbers in Base 10 only. The string may begin with a negative.
 //Empty strings, too long strings, or strings containing anything other than


### PR DESCRIPTION
Most parts of bedtools — e.g. the main BED file parsers — can accept either Unix- or Windows-style line termination, as they explicitly trim `'\n'` and `'\r'` characters from lines as they are read in. At present, reading in genome files does not do that, leading to obscure error messages such as encountered by the OP in #998.

This PR adds a utility function to trim any CR or LF characters at the end of a string, and uses it in `NewGenomeFile::loadGenomeFileIntoMap()` which did not previously accept Windows-style CRLF-delimited files. I didn't alter `GenomeFile`; hopefully most bedtools code uses the `New…` class!

There are several other file reading classes that do their own newline trimming. It's a low priority, but they could be altered to use this utility function too if desired.