### PR TITLE
Avoid dangling reference to temporary string object

### DIFF
--- a/src/utils/Fasta/Fasta.cpp
+++ b/src/utils/Fasta/Fasta.cpp
@@ -35,7 +35,7 @@ FastaIndex::FastaIndex(bool useFullHeader)
 void FastaIndex::readIndexFile(string fname) {
 
     faidx = fai_load(fname.c_str());
-    const char *idx_path = (fname + ".fai").c_str();
+    string idx_path = fname + ".fai";
 
     // NOTE: can use faidx_set_cache_size to improve performance of repeated queries.
     if(faidx == NULL) {
@@ -44,7 +44,7 @@ void FastaIndex::readIndexFile(string fname) {
     }
 
     struct stat index_attr, fasta_attr;
-    stat(idx_path, &index_attr);
+    stat(idx_path.c_str(), &index_attr);
     stat(fname.c_str(), &fasta_attr);
     if(fasta_attr.st_mtime > index_attr.st_mtime) {
         cerr << "Warning: the index file is older than the FASTA file." << endl;


### PR DESCRIPTION
Clang produces the following warning for _Fasta.cpp_ — and `idx_path` does indeed point to something no longer valid after the semicolon:

```
src/utils/Fasta/Fasta.cpp:38:28: warning: object backing the pointer will be destroyed at the end of the full-expression [-Wdangling-gsl]
    const char *idx_path = (fname + ".fai").c_str();
                           ^~~~~~~~~~~~~~~~
```

There are two other instances of the same warning, in _BamAncillary.cpp_, but that code is never used so doesn't matter too much.