### PR TITLE
Add missing <cstdint> include

### DIFF
--- a/src/utils/general/ParseTools.h
+++ b/src/utils/general/ParseTools.h
@@ -16,6 +16,7 @@
 #include "string.h"
 #include <cstdio>
 #include <cstdlib>
+#include <cstdint>
 
 using namespace std;
 


### PR DESCRIPTION
* breaks build with GCC 13: https://bugs.gentoo.org/895860