### PR TITLE
workaround for issue arq5x#1049

### DIFF
--- a/src/utils/FileRecordTools/Records/Record.h
+++ b/src/utils/FileRecordTools/Records/Record.h
@@ -24,7 +24,7 @@ class ChromIdLookup;
 
 static inline const char* buffer_printf(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
 static inline const char* buffer_printf(const char* fmt, ...) {
-	static char static_buffer[1024];
+	static char static_buffer[8192];
 	static char* dynamic_buffer = NULL;
 	static size_t dynamic_buffer_size;
 


### PR DESCRIPTION
This is a workaround for the issue reported in arq5x#1049.
Printing buffer is increased from 1024 to 8192 to handle very long bed entry, such as a gene's BED12 entry consisting of very many exons. 
True solution is desired than this workaround. 