### PR TITLE
add cstdint imports to ParseTools

### DIFF
--- a/src/utils/general/ParseTools.cpp
+++ b/src/utils/general/ParseTools.cpp
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <cstdio>
 #include <cstdlib>
+#include <cstdint>
 #include <sstream>
 
 

--- a/src/utils/general/ParseTools.h
+++ b/src/utils/general/ParseTools.h
@@ -15,6 +15,7 @@
 #include <vector>
 #include "string.h"
 #include <cstdio>
+#include <cstdint>
 #include <cstdlib>
 
 using namespace std;


### PR DESCRIPTION
Adding these imports was necessary to compile the code successfully with gcc 13.2.1 20230801 on an up-to-date Arch Linux system. 

This was also reported as on issue on Fedora 38, in https://github.com/arq5x/bedtools2/issues/1056