### PR TITLE
Fix various GCC 13 warnings and errors

### DIFF
--- a/src/utils/FileRecordTools/Records/Record.h
+++ b/src/utils/FileRecordTools/Records/Record.h
@@ -73,7 +73,7 @@ public:
 	virtual void printNull(string &) const {}
 	friend ostream &operator << (ostream &out, const Record &record);
 
-	virtual const Record & operator=(const Record &);
+	const Record & operator=(const Record &);
 
 	virtual bool isZeroBased() const {return true;};
 

--- a/src/utils/NewChromsweep/NewChromsweep.cpp
+++ b/src/utils/NewChromsweep/NewChromsweep.cpp
@@ -26,11 +26,11 @@ NewChromSweep::NewChromSweep(ContextIntersect *context)
      _wasInitialized(false),
      _currQueryRec(NULL),
      _runToQueryEnd(_context->getRunToQueryEnd()),
+     _runToDbEnd(false),
      _lexicoDisproven(false),
      _lexicoAssumed(false),
      _lexicoAssumedFileIdx(-1),
-     _testLastQueryRec(false),
-     _runToDbEnd(false)
+     _testLastQueryRec(false)
 {
 	_filePrevChrom.resize(_numFiles);
 	_runToDbEnd = context->shouldRunToDbEnd();

--- a/src/utils/NewChromsweep/NewChromsweep.h
+++ b/src/utils/NewChromsweep/NewChromsweep.h
@@ -90,8 +90,7 @@ protected:
     string _currQueryChromName;
     string _prevQueryChromName;
     bool _runToQueryEnd;
-	bool _runToDbEnd;
-
+    bool _runToDbEnd;
 
     virtual void masterScan(RecordKeyVector &retList);
 

--- a/src/utils/general/ParseTools.cpp
+++ b/src/utils/general/ParseTools.cpp
@@ -2,6 +2,7 @@
 #include <climits>
 #include <cctype>
 #include <cstring>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <sstream>

--- a/src/utils/general/ParseTools.h
+++ b/src/utils/general/ParseTools.h
@@ -16,10 +16,9 @@
 #include "string.h"
 #include <cstdio>
 #include <cstdlib>
+#include "BedtoolsTypes.h"
 
 using namespace std;
-
-typedef int64_t CHRPOS;
 
 bool isNumeric(const string &str);
 bool isInteger(const string &str);
@@ -54,7 +53,7 @@ void int2str(U number, T& buffer, bool appendToBuf = false)
 
 	bool neg = number < 0;
 	if(neg) number = -number;
-	uint32_t n;
+	unsigned int n;
 	for(n = 0; number; number /= 10)
 		tmp[12 - ++n] = number % 10 + '0';
 	if(neg) tmp[12 - ++n] = '-';


### PR DESCRIPTION
As noted in #1056 et al, on recent platforms _ParseTools.cpp_/_.h_ fail to compile due to `uint32_t` not being declared. The obvious fix is to add `#include <cstdint>` but we can tidy things up a bit by fixing this differently. This PR fixes that build failure and also fixes several warnings encountered with GCC 13:

Due to improvements in system and/or compiler header cleanliness, where previously _ParseTools.{cpp,h}_'s headers have included `<cstdint>` as a byproduct, this no longer occurs. Hence:
 - Ordinary unsigned is appropriate for the int2str() variable anyway;
 - Get CHRPOS from BedtoolsTypes.h instead of typedeffing it ourselves;
 - ParseTools.cpp's isHeaderLine() does use uint32_t, so include `<cstdint>` from the .cpp file for good measure.

Other warnings:
- Assignment operators should not be virtual (avoids "Record::operator= was hidden" warnings).
- List member initialisers in the same order in which they are declared (avoids "_testLastQueryRec will be initialized after _runToDbEnd" warnings).

Fixes #1056. Closes #1045 and closes #1066.