### PR TITLE
Support native builds on Windows with MinGW/UCRT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,13 @@ endif
 BT_LDFLAGS =
 BT_LIBS    = -lz -lm -lbz2 -llzma -lpthread
 
+# Support building on MSYS2
+UNAME := $(shell sh -c 'uname 2>/dev/null || echo Unknown')
+ifeq (MINGW64_NT,$(findstring MINGW64_NT,$(UNAME)))
+BT_CPPFLAGS += -D_GNU_SOURCE -D_DEFAULT_SOURCE
+BT_LIBS += -lwsock32
+endif
+
 prefix ?= /usr/local
 
 SUBDIRS = $(SRC_DIR)/annotateBed \

--- a/src/complementFile/complementFile.h
+++ b/src/complementFile/complementFile.h
@@ -32,7 +32,7 @@ public:
 
 
 protected:
-	FileRecordMergeMgr *_frm;
+	FileRecordMergeMgr *_frm{};
 	Bed3Interval _outRecord;
 	string _currChrom;
 	const NewGenomeFile *_genomeFile;

--- a/src/mergeFile/mergeFile.h
+++ b/src/mergeFile/mergeFile.h
@@ -29,7 +29,7 @@ public:
 
 
 protected:
-	FileRecordMergeMgr *_frm;
+	FileRecordMergeMgr *_frm{};
 
 	virtual ContextMerge *upCast(ContextBase *context) { return static_cast<ContextMerge *>(context); }
 

--- a/src/randomBed/randomBed.h
+++ b/src/randomBed/randomBed.h
@@ -46,7 +46,7 @@ private:
     int _seed;
     bool _haveSeed;
 
-    GenomeFile *_genome;
+    GenomeFile *_genome{};
     CHRPOS _length;
     uint32_t _numToGenerate;
     

--- a/src/regressTest/RegressTest.cpp
+++ b/src/regressTest/RegressTest.cpp
@@ -68,7 +68,11 @@ bool RegressTest::init(int argc, char **argv)
 		}
 	}
 	_tmpDirname += timeStr;
+#if (defined(_WIN32) || defined(__WIN32__))
+	int mkdirRetval = _mkdir(_tmpDirname.c_str()); //mkdir directory.
+#else
 	int mkdirRetval = mkdir(_tmpDirname.c_str(), S_IRWXU | S_IRWXG | S_IRWXO ); //mkdir directory with all permissions allowed.
+#endif
 	if (mkdirRetval != 0) {
 		fprintf(stderr, "Error: Unable to create temporary output directory %s.\n", _tmpDirname.c_str());
 		return false;

--- a/src/regressTest/RegressTest.h
+++ b/src/regressTest/RegressTest.h
@@ -12,6 +12,10 @@
 #include <cstdio>
 #include <vector>
 #include <fstream>
+#if (defined(_WIN32) || defined(__WIN32__))
+#include <direct.h>
+#endif
+
 
 using namespace std;
 

--- a/src/regressTest/RegressTest.h
+++ b/src/regressTest/RegressTest.h
@@ -46,7 +46,7 @@ protected:
 	int _filesPerRun;
 	vector<string> _filePrecessorOptions;
 
-	FILE *_fpReportFile;
+	FILE *_fpReportFile{};
 	ifstream _configFile;
 
 	typedef vector<pair<string, string> > fileListType;

--- a/src/reldist/reldist.h
+++ b/src/reldist/reldist.h
@@ -56,7 +56,7 @@ private:
     size_t _tot_queries;
     
     // instance of a bed file class.
-    BedFile *_bedA, *_bedB;
+    BedFile *_bedA{}, *_bedB{};
     bool _summary;
 
     //------------------------------------------------

--- a/src/spacingFile/spacingFile.h
+++ b/src/spacingFile/spacingFile.h
@@ -30,7 +30,7 @@ protected:
     Record *_currRec;
     string _distance;
 
-    FileRecordMgr *_inputFile;
+    FileRecordMgr *_inputFile{};
     virtual ContextSpacing *upCast(ContextBase *context) { return static_cast<ContextSpacing *>(context); }
 
 

--- a/src/split/splitBed.h
+++ b/src/split/splitBed.h
@@ -29,7 +29,7 @@ private:
     std::string bedFileName;
     std::string outfileprefix;
     unsigned int num_chuncks;
-    int bedType;
+    int bedType{};
     std::vector<BED> items;
     
     void usage(std::ostream& out);

--- a/src/summaryFile/summaryFile.h
+++ b/src/summaryFile/summaryFile.h
@@ -31,7 +31,7 @@ public:
 
 
 protected:
-    FileRecordMgr *_frm;
+    FileRecordMgr *_frm{};
     Record *_currRec;
     uint64_t _total_length;
     uint64_t _total_intervals;
@@ -39,7 +39,7 @@ protected:
     const vector<string> &_chromList;
     map<string, vector<Interval>, std::less<string> > _chromData;
 
-    FileRecordMgr *_inputFile;
+    FileRecordMgr *_inputFile{};
     virtual ContextSummary *upCast(ContextBase *context) { return static_cast<ContextSummary *>(context); }
 
 };

--- a/src/utils/BamTools/include/api/BamAux.h
+++ b/src/utils/BamTools/include/api/BamAux.h
@@ -1,4 +1,5 @@
 #include <string>
+#include <cstdint>
 
 #ifndef BAMAUX_H
 #define BAMAUX_H

--- a/src/utils/Contexts/ContextBase.cpp
+++ b/src/utils/Contexts/ContextBase.cpp
@@ -69,7 +69,8 @@ ContextBase::ContextBase()
   _allFileHaveLeadingZeroInChromNames(UNTESTED),
   _noEnforceCoordSort(false),
   _inheader(false),
-  _nameConventionWarningTripped(false)
+  _nameConventionWarningTripped(false),
+  _runToQueryEnd(false)
 
 {
 	_programNames["intersect"] = INTERSECT;

--- a/src/utils/Contexts/ContextBase.h
+++ b/src/utils/Contexts/ContextBase.h
@@ -215,7 +215,7 @@ protected:
     int _bamHeaderAndRefIdx;
     int _maxNumDatabaseFields;
     bool _useFullBamTags;
-	bool _isCram;   // Used when a "BAM" type which is actually a CRAM
+	bool _isCram{};   // Used when a "BAM" type which is actually a CRAM
 
 	int _numOutputRecords;
 
@@ -247,9 +247,9 @@ protected:
 
 	//set cmd line params and counter, i, as members so code
 	//is more readable (as opposed to passing all 3 everywhere).
-	int _argc;
-	char **_argv;
-	int _i;
+	int _argc{};
+	char **_argv{};
+	int _i{};
 
 	//track whether each file has the letters chr in their chrom names.
 	//this is needed for enforcing consistent naming conventions across

--- a/src/utils/Contexts/ContextClosest.cpp
+++ b/src/utils/Contexts/ContextClosest.cpp
@@ -12,6 +12,8 @@ ContextClosest::ContextClosest()
 	_ignoreOverlaps(false),
 	_ignoreUpstream(false),
 	_ignoreDownstream(false),
+	_forceUpstream(false),
+	_forceDownstream(false),
 	_reportDistance(false),
 	_signDistance(false),
 	_haveStrandedDistMode(false),

--- a/src/utils/Contexts/ContextComplement.h
+++ b/src/utils/Contexts/ContextComplement.h
@@ -21,7 +21,7 @@ public:
 
 private:
   bool handle_limit_chroms();
-  bool _onlyChromsWithBedRecords;
+  bool _onlyChromsWithBedRecords{};
 protected:
 
 };

--- a/src/utils/Contexts/ContextCoverage.h
+++ b/src/utils/Contexts/ContextCoverage.h
@@ -26,7 +26,7 @@ private:
     bool _count;
     bool _perBase;
     bool _showHist;
-    bool _mean;
+    bool _mean{};
     coverageType _coverageType;
 
 	bool handle_c();

--- a/src/utils/Contexts/ContextIntersect.h
+++ b/src/utils/Contexts/ContextIntersect.h
@@ -109,8 +109,8 @@ public:
 
 protected:
 
-	BlockMgr *_splitBlockMgr;
-	bool _shouldRunToDbEnd;
+	BlockMgr *_splitBlockMgr{};
+	bool _shouldRunToDbEnd{};
 
 	virtual bool handle_a();
 	virtual bool handle_abam();

--- a/src/utils/Fasta/Fasta.h
+++ b/src/utils/Fasta/Fasta.h
@@ -20,7 +20,9 @@
 #include "bedFile.h"
 #include "htslib/faidx.h"
 #include <sys/stat.h>
+#if (!defined(_WIN32) || !defined(__WIN32__))
 #include <sys/mman.h>
+#endif
 #include "split.h"
 #include <stdlib.h>
 #include <ctype.h>

--- a/src/utils/Fasta/Fasta.h
+++ b/src/utils/Fasta/Fasta.h
@@ -36,7 +36,7 @@ class FastaIndexEntry {
         FastaIndexEntry(void);
         ~FastaIndexEntry(void);
         string name;  // sequence name
-        CHRPOS length;  // length of sequence
+        CHRPOS length{};  // length of sequence
         void clear(void);
 };
 

--- a/src/utils/Fasta/LargeFileSupport.h
+++ b/src/utils/Fasta/LargeFileSupport.h
@@ -2,7 +2,7 @@
 
 #define _FILE_OFFSET_BITS 64
 
-#ifdef WIN32
+#ifdef  _MSC_VER
 #define ftell64(a)     _ftelli64(a)
 #define fseek64(a,b,c) _fseeki64(a,b,c)
 typedef __int64_t off_type;

--- a/src/utils/FileRecordTools/FileReaders/InputStreamMgr.cpp
+++ b/src/utils/FileRecordTools/FileReaders/InputStreamMgr.cpp
@@ -86,7 +86,7 @@ bool InputStreamMgr::init()
 			_isStdin = true;
 		}
 		
-		_inputFileStream = new ifstream(_filename.c_str());
+		_inputFileStream = new ifstream(_filename.c_str(), std::ios::binary);
 		if (_inputFileStream->fail()) {
 			cerr << "Error: Unable to open file " << _filename << ". Exiting." << endl;
 			delete _inputFileStream;

--- a/src/utils/FileRecordTools/FileReaders/InputStreamMgr.h
+++ b/src/utils/FileRecordTools/FileReaders/InputStreamMgr.h
@@ -51,7 +51,7 @@ private:
 	BTlist<int> _scanBuffer;
 	string _saveDataStr;
 	InflateStreamBuf *_infStreamBuf;
-	istream * _finalInputStream;
+	istream * _finalInputStream{};
 	istream *_oldInputStream;
 	bool _isStdin;
 	bool _isGzipped;

--- a/src/utils/FileRecordTools/Records/GffRecord.h
+++ b/src/utils/FileRecordTools/Records/GffRecord.h
@@ -38,7 +38,7 @@ public:
 protected:
 	void printRemainingFields(string &outbuf) const;
 
-	int _numFields;
+	int _numFields{};
 	string _source;
 	string _frame;
 	string _group;

--- a/src/utils/FileRecordTools/Records/PlusFields.h
+++ b/src/utils/FileRecordTools/Records/PlusFields.h
@@ -32,7 +32,7 @@ public:
 
 protected:
 	vector<string> _fields;
-	int _numOffsetFields; //could be 3 for BedPlus, but GFF has 8 or 9
+	int _numOffsetFields{}; //could be 3 for BedPlus, but GFF has 8 or 9
 };
 
 

--- a/src/utils/FileRecordTools/Records/RecordList.h
+++ b/src/utils/FileRecordTools/Records/RecordList.h
@@ -48,7 +48,7 @@ public:
 
 private:
 
-	Record * _val;
+	Record * _val{};
 	RecordListNode *_next;
 };
 

--- a/src/utils/GenomeFile/GenomeFile.h
+++ b/src/utils/GenomeFile/GenomeFile.h
@@ -65,7 +65,7 @@ private:
     vector<string> _chromList;
 
     // projecting chroms into a single coordinate system
-    CHRPOS _genomeLength;
+    CHRPOS _genomeLength{};
     vector<CHRPOS> _startOffsets;
     
 };

--- a/src/utils/GenomeFile/NewGenomeFile.h
+++ b/src/utils/GenomeFile/NewGenomeFile.h
@@ -48,20 +48,20 @@ public:
 
 private:
     string  _genomeFileName;
-    istream   *_genomeFile;
+    istream   *_genomeFile{};
     typedef map<string, pair<CHRPOS, int> > lookupType;
     lookupType _chromSizeIds;
     vector<string> _chromList;
     int _maxId;
 
     // projecting chroms onto a single coordinate system
-    CHRPOS _genomeLength;
+    CHRPOS _genomeLength{};
     vector<CHRPOS> _startOffsets;
     
     //cache members for quick lookup
     string _currChromName;
-    CHRPOS _currChromSize;
-    int _currChromId;
+    CHRPOS _currChromSize{};
+    int _currChromId{};
 
 };
 

--- a/src/utils/KeyListOps/KeyListOpsMethods.h
+++ b/src/utils/KeyListOps/KeyListOpsMethods.h
@@ -105,9 +105,9 @@ private:
 
 	typedef enum { UNSORTED, ASC, DESC} SORT_TYPE;
 
-	bool _nonNumErrFlag;
+	bool _nonNumErrFlag{};
 	string _errMsg;
-	bool _isBam;
+	bool _isBam{};
 
 	typedef multimap<int, string, less<int> > histAscType;
 	typedef multimap<int, string, greater<int> > histDescType;

--- a/src/utils/bedFile/bedFile.h
+++ b/src/utils/bedFile/bedFile.h
@@ -175,8 +175,8 @@ public:
 */
 struct MATE {
     BED bed;
-    int lineNum;
-    MATE *mate;
+    int lineNum{};
+    MATE *mate{};
 };
 
 
@@ -483,10 +483,10 @@ public:
 
     // the bedfile with which this instance is associated
     string bedFile;
-    unsigned int bedType;  // 3-6, 12 for BED
+    unsigned int bedType{};  // 3-6, 12 for BED
                            // 9 for GFF
-    bool isBed12;          // is it file of true blocked BED12 records?
-    bool isZeroBased;
+    bool isBed12{};          // is it file of true blocked BED12 records?
+    bool isZeroBased{};
 
     // Main data structures used by BEDTools
     masterBedCovMap      bedCovMap;
@@ -496,7 +496,7 @@ public:
     masterBedMapNoBin    bedMapNoBin;
     
     BedLineStatus _status;
-    int _lineNum;
+    int _lineNum{};
 
 private:
 
@@ -505,21 +505,21 @@ private:
     bool _isVcf;
     bool _typeIsKnown;        // do we know the type?   (i.e., BED, GFF, VCF)
     FileType   _fileType;     // what is the file type? (BED? GFF? VCF?)
-    istream   *_bedStream;
+    istream   *_bedStream{};
     string _bedLine;
 
     BED _nullBed;
     string _header;
-    bool _firstLine;
+    bool _firstLine{};
     vector<string> _bedFields;
-    unsigned int _numFields;
+    unsigned int _numFields{};
     CHRPOS _merged_start;
     CHRPOS _merged_end;
     string _merged_chrom;
     CHRPOS _prev_start;
     string _prev_chrom;
     unsigned long _total_length;
-    unsigned long _total_flattened_length;
+    unsigned long _total_flattened_length{};
 
     void setZeroBased(bool zeroBased);
     void setGff (bool isGff);

--- a/src/utils/bedFilePE/bedFilePE.h
+++ b/src/utils/bedFilePE/bedFilePE.h
@@ -80,13 +80,13 @@ public:
 
 
     string bedFile;
-    unsigned int bedType;
+    unsigned int bedType{};
 
     masterMateMap bedMapEnd1;
     masterMateMap bedMapEnd2;
 
 private:
-    istream *_bedStream;
+    istream *_bedStream{};
 
     // methods
     BedLineStatus parseLine (BEDPE &bedpe, const vector<string> &lineVector, int &lineNum);

--- a/src/utils/chromsweep/chromsweep.h
+++ b/src/utils/chromsweep/chromsweep.h
@@ -62,14 +62,14 @@ private:
 
     // instances of a bed file class.
     BedFile *_query, *_db;
-    float _overlapFraction;
+    float _overlapFraction{};
     // do we care about strandedness.
-    bool _sameStrand;
-    bool _diffStrand;
+    bool _sameStrand{};
+    bool _diffStrand{};
     // do we care about reciprocal overlap?
-    bool _reciprocal;
+    bool _reciprocal{};
     // should we merge overlapping intervals before computing overlaps?
-    bool _useMergedIntervals;
+    bool _useMergedIntervals{};
 
     /* 
        a cache of still active features from the database file\

--- a/src/utils/fileType/FileRecordTypeChecker.cpp
+++ b/src/utils/fileType/FileRecordTypeChecker.cpp
@@ -269,7 +269,7 @@ bool FileRecordTypeChecker::isBedFormat() {
 		return false;
 	}
 	//the 2nd and 3rd fields must be numeric.
-	if (!isInteger(_tokenizer.getElem(1)) || !isInteger(_tokenizer.getElem(2))) {
+	if (!isBedInteger(_tokenizer.getElem(1)) || !isBedInteger(_tokenizer.getElem(2))) {
 		return false;
 	}
 

--- a/src/utils/fileType/FileRecordTypeChecker.h
+++ b/src/utils/fileType/FileRecordTypeChecker.h
@@ -96,7 +96,7 @@ private:
 	Tokenizer _tokenizer;
 
 	int _firstValidDataLineIdx;
-	int _numBytesInBuffer; //this will hold the length of the buffer after the scan.
+	int _numBytesInBuffer{}; //this will hold the length of the buffer after the scan.
 
 	int _numFields;
 	bool _isBinary;

--- a/src/utils/fileType/fileType.cpp
+++ b/src/utils/fileType/fileType.cpp
@@ -20,7 +20,7 @@ not a pipe/device.
 This implies that the file can be opened/closed/seek'd multiple times without losing information
 */
 bool isRegularFile(const string& filename) {
-    struct stat buf ;
+    struct stat buf{} ;
     int i;
 
     i = stat(filename.c_str(), &buf);

--- a/src/utils/general/InflateStreamBuf.h
+++ b/src/utils/general/InflateStreamBuf.h
@@ -140,11 +140,11 @@ public:
 
 protected:
 	std::istream* in;
-	unsigned char buffin[GZBUFSIZ];
-	unsigned char buffout[GZBUFSIZ];
+	unsigned char buffin[GZBUFSIZ]{};
+	unsigned char buffout[GZBUFSIZ]{};
 	char* buffer;
 	size_t bufsiz;
-	z_stream strm;
+	z_stream strm{};
 	int status_flag;
 };
 

--- a/src/utils/general/ParseTools.cpp
+++ b/src/utils/general/ParseTools.cpp
@@ -22,7 +22,7 @@ bool isNumeric(const string &str) {
 }
 
 //As above, but does not allow decimal points
-bool isInteger(const string &str) {
+bool isBedInteger(const string &str) {
 	bool hasDigits = false;
 	for (int i=0; i < (int)str.size(); i++) {
 		char currChar = str[i];

--- a/src/utils/general/ParseTools.h
+++ b/src/utils/general/ParseTools.h
@@ -21,8 +21,7 @@
 using namespace std;
 
 bool isNumeric(const string &str);
-bool isInteger(const string &str);
-
+bool isBedInteger(const string &str);
 void trimNewlines(string& str);
 
 //This method is a faster version of atoi, but is limited to a maximum of

--- a/src/utils/gzstream/gzstream.h
+++ b/src/utils/gzstream/gzstream.h
@@ -47,10 +47,10 @@ private:
     static const int bufferSize = 47+256;    // size of data buff
     // totals 512 bytes under g++ for igzstream at the end.
 
-    gzFile           file;               // file handle for compressed file
-    char             buffer[bufferSize]; // data buffer
+    gzFile           file{};               // file handle for compressed file
+    char             buffer[bufferSize]{}; // data buffer
     char             opened;             // open/close state of stream
-    int              mode;               // I/O mode
+    int              mode{};               // I/O mode
 
     int flush_buffer();
 public:

--- a/src/utils/htslib/Makefile
+++ b/src/utils/htslib/Makefile
@@ -184,7 +184,9 @@ config.h:
 	echo '#define HAVE_LZMA_H 1' >> $@
 	echo '#endif' >> $@
 	echo '#define HAVE_FSEEKO 1' >> $@
+	echo '#if (!defined(_WIN32) || !defined(__WIN32__))' >> $@
 	echo '#define HAVE_DRAND48 1' >> $@
+	echo '#endif' >> $@
 
 # And similarly for htslib.pc.tmp ("pkg-config template").  No dependency
 # on htslib.pc.in listed, as if that file is newer the usual way to regenerate

--- a/src/utils/htslib/bgzf.c
+++ b/src/utils/htslib/bgzf.c
@@ -2025,7 +2025,7 @@ int bgzf_index_load(BGZF *fp, const char *bname, const char *suffix)
     return -1;
 }
 
-int bgzf_useek(BGZF *fp, long uoffset, int where)
+int bgzf_useek(BGZF *fp, off_t uoffset, int where)
 {
     if ( !fp->is_compressed )
     {
@@ -2082,7 +2082,7 @@ int bgzf_useek(BGZF *fp, long uoffset, int where)
     return 0;
 }
 
-long bgzf_utell(BGZF *fp)
+off_t bgzf_utell(BGZF *fp)
 {
     return fp->uncompressed_address;    // currently maintained only when reading
 }

--- a/src/utils/htslib/hfile.c
+++ b/src/utils/htslib/hfile.c
@@ -96,6 +96,7 @@ for seek():
 hFILE *hfile_init(size_t struct_size, const char *mode, size_t capacity)
 {
     hFILE *fp = (hFILE *) malloc(struct_size);
+    memset(fp, 0, struct_size);
     if (fp == NULL) goto error;
 
     if (capacity == 0) capacity = 32768;
@@ -104,7 +105,7 @@ hFILE *hfile_init(size_t struct_size, const char *mode, size_t capacity)
 
     fp->buffer = (char *) malloc(capacity);
     if (fp->buffer == NULL) goto error;
-
+    memset(fp->buffer, 0, capacity);
     fp->begin = fp->end = fp->buffer;
     fp->limit = &fp->buffer[capacity];
 

--- a/src/utils/htslib/hts.c
+++ b/src/utils/htslib/hts.c
@@ -1118,14 +1118,14 @@ BGZF *hts_get_bgzfp(htsFile *fp)
     else
         return NULL;
 }
-int hts_useek(htsFile *fp, long uoffset, int where)
+int hts_useek(htsFile *fp, off_t uoffset, int where)
 {
     if (fp->is_bgzf)
         return bgzf_useek(fp->fp.bgzf, uoffset, where);
     else
         return (hseek(fp->fp.hfile, uoffset, SEEK_SET) >= 0)? 0 : -1;
 }
-long hts_utell(htsFile *fp)
+off_t hts_utell(htsFile *fp)
 {
     if (fp->is_bgzf)
         return bgzf_utell(fp->fp.bgzf);

--- a/src/utils/htslib/htslib.mk
+++ b/src/utils/htslib/htslib.mk
@@ -147,28 +147,28 @@ HTSLIB_ALL = \
 	$(HTSDIR)/os/rand.c
 
 $(HTSDIR)/config.h:
-	+cd $(HTSDIR) && $(MAKE) config.h
+	+cd $(HTSDIR) && "$(MAKE)" config.h
 
 $(HTSDIR)/libhts.a: $(HTSLIB_ALL)
-	+cd $(HTSDIR) && $(MAKE) lib-static
+	+cd $(HTSDIR) && "$(MAKE)" lib-static
 
 $(HTSDIR)/libhts.so $(HTSDIR)/libhts.dylib: $(HTSLIB_ALL)
-	+cd $(HTSDIR) && $(MAKE) lib-shared
+	+cd $(HTSDIR) && "$(MAKE)" lib-shared
 
 $(HTSDIR)/bgzip: $(HTSDIR)/bgzip.c $(HTSLIB_PUBLIC_HEADERS)
-	+cd $(HTSDIR) && $(MAKE) bgzip
+	+cd $(HTSDIR) && "$(MAKE)" bgzip
 
 $(HTSDIR)/htsfile: $(HTSDIR)/htsfile.c $(HTSLIB_PUBLIC_HEADERS)
-	+cd $(HTSDIR) && $(MAKE) htsfile
+	+cd $(HTSDIR) && "$(MAKE)" htsfile
 
 $(HTSDIR)/tabix: $(HTSDIR)/tabix.c $(HTSLIB_PUBLIC_HEADERS)
-	+cd $(HTSDIR) && $(MAKE) tabix
+	+cd $(HTSDIR) && "$(MAKE)" tabix
 
 $(HTSDIR)/htslib_static.mk: $(HTSDIR)/htslib.pc.tmp
-	+cd $(HTSDIR) && $(MAKE) htslib_static.mk
+	+cd $(HTSDIR) && "$(MAKE)" htslib_static.mk
 
 $(HTSDIR)/htslib.pc.tmp:
-	+cd $(HTSDIR) && $(MAKE) htslib.pc.tmp
+	+cd $(HTSDIR) && "$(MAKE)" htslib.pc.tmp
 
 # Rules for phony targets.  You may wish to have your corresponding phony
 # targets invoke these in addition to their own recipes:
@@ -176,6 +176,6 @@ $(HTSDIR)/htslib.pc.tmp:
 #	clean: clean-htslib
 
 all-htslib clean-htslib install-htslib plugins-htslib:
-	+cd $(HTSDIR) && $(MAKE) $(@:-htslib=)
+	+cd $(HTSDIR) && "$(MAKE)" $(@:-htslib=)
 
 .PHONY: all-htslib clean-htslib install-htslib plugins-htslib

--- a/src/utils/htslib/htslib/bgzf.h
+++ b/src/utils/htslib/htslib/bgzf.h
@@ -328,7 +328,7 @@ typedef struct __kstring_t {
      *
      *  Returns 0 on success and -1 on error.
      */
-    int bgzf_useek(BGZF *fp, long uoffset, int where) HTS_RESULT_USED;
+    int bgzf_useek(BGZF *fp, off_t uoffset, int where) HTS_RESULT_USED;
 
     /**
      *  Position in uncompressed BGZF
@@ -337,7 +337,7 @@ typedef struct __kstring_t {
      *
      *  Returns the current offset on success and -1 on error.
      */
-    long bgzf_utell(BGZF *fp);
+    off_t bgzf_utell(BGZF *fp);
 
     /**
      * Tell BGZF to build index while compressing.

--- a/src/utils/htslib/vcf_sweep.c
+++ b/src/utils/htslib/vcf_sweep.c
@@ -49,8 +49,8 @@ struct _bcf_sweep_t
 };
 
 BGZF *hts_get_bgzfp(htsFile *fp);
-int hts_useek(htsFile *file, long uoffset, int where);
-long hts_utell(htsFile *file);
+int hts_useek(htsFile *file, off_t uoffset, int where);
+off_t hts_utell(htsFile *file);
 
 static inline int sw_rec_equal(bcf_sweep_t *sw, bcf1_t *rec)
 {
@@ -146,7 +146,7 @@ bcf1_t *bcf_sweep_fwd(bcf_sweep_t *sw)
 {
     if ( sw->direction==SW_BWD ) sw_seek(sw, SW_FWD);
 
-    long pos = hts_utell(sw->file);
+    off_t pos = hts_utell(sw->file);
 
     bcf1_t *rec = &sw->rec[0];
     int ret = bcf_read1(sw->file, sw->hdr, rec);

--- a/src/utils/lineFileUtilities/lineFileUtilities.h
+++ b/src/utils/lineFileUtilities/lineFileUtilities.h
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <sstream>
 #include <iostream>
+#include <cstdint>
 
 using namespace std;
 

--- a/src/utils/sequenceUtilities/sequenceUtils.h
+++ b/src/utils/sequenceUtilities/sequenceUtils.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
 
 using namespace std;
 

--- a/src/utils/tabFile/tabFile.h
+++ b/src/utils/tabFile/tabFile.h
@@ -56,7 +56,7 @@ public:
 private:
 
     // data
-    istream *_tabStream;
+    istream *_tabStream{};
     string _tabFile;
 
     // methods

--- a/test/bamtobed/test-bamtobed.sh
+++ b/test/bamtobed/test-bamtobed.sh
@@ -6,7 +6,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 	else
 		FAILURES=$(expr $FAILURES + 1);

--- a/test/bamtofastq/test-bamtofastq.sh
+++ b/test/bamtofastq/test-bamtofastq.sh
@@ -6,7 +6,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
 		echo ok
 	else
     	FAILURES=$(expr $FAILURES + 1);

--- a/test/bed12tobed6/test-bed12tobed6.sh
+++ b/test/bed12tobed6/test-bed12tobed6.sh
@@ -5,7 +5,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 	else
     	FAILURES=$(expr $FAILURES + 1);

--- a/test/bedtobam/test-bedtobam.sh
+++ b/test/bedtobam/test-bedtobam.sh
@@ -6,7 +6,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 	else
 		FAILURES=$(expr $FAILURES + 1);

--- a/test/bigchroms/make-big-chrom.py
+++ b/test/bigchroms/make-big-chrom.py
@@ -10,13 +10,13 @@ linelen = 200
 extra = "ACTGACCCCGAGACGTTTGCATCCTGCACAGCTAGAGATCCTTTATTAAAAGCACACTGT"
 
 with open("bigx.fasta", "wb") as fh:
-    fh.write(">chrbig\n")
+    fh.write(b">chrbig\n")
     line = ("N" * linelen) + "\n"
     for i in xrange(0, size, len(line) - 1):
-        fh.write(line)
-    fh.write(extra + "\n")
+        fh.write(bytes(line, "utf8"))
+    fh.write(bytes(extra + "\n", "utf8"))
 fh.close()
 
 with open("bigx.fasta.fai", "wb") as fh:
-    fh.write("chrbig\t%d\t8\t%d\t%d\n" % (size + len(extra), linelen, linelen+1))
+    fh.write(b"chrbig\t%d\t8\t%d\t%d\n" % (size + len(extra), linelen, linelen+1))
 

--- a/test/bigchroms/test-bigchroms.sh
+++ b/test/bigchroms/test-bigchroms.sh
@@ -6,7 +6,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 	else
     	FAILURES=$(expr $FAILURES + 1);

--- a/test/closest/kclosest/test-kclosest.sh
+++ b/test/closest/kclosest/test-kclosest.sh
@@ -12,7 +12,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 	else
     	FAILURES=$(expr $FAILURES + 1);

--- a/test/closest/sortAndNaming/test-sort-and-naming.sh
+++ b/test/closest/sortAndNaming/test-sort-and-naming.sh
@@ -13,7 +13,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 	else
     	FAILURES=$(expr $FAILURES + 1);

--- a/test/closest/test-closest.sh
+++ b/test/closest/test-closest.sh
@@ -5,7 +5,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 	else
     	FAILURES=$(expr $FAILURES + 1);
@@ -254,7 +254,7 @@ check obs exp
 rm obs exp
 
 ###########################################################
-# test diff strand 
+# test diff -Z strand 
 ###########################################################
 echo -e "    closest.t21...\c"
 echo \
@@ -276,7 +276,7 @@ rm obs exp
 
 
 ###########################################################
-# test 2 dbs, tie mode = all, diff strand
+# test 2 dbs, tie mode = all, diff -Z strand
 ###########################################################
 echo -e "    closest.t23...\c"
 echo \

--- a/test/cluster/test-cluster.sh
+++ b/test/cluster/test-cluster.sh
@@ -5,7 +5,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 
 	else

--- a/test/complement/test-complement.sh
+++ b/test/complement/test-complement.sh
@@ -5,7 +5,7 @@ FAILURES=0;
 
 check()
 {
-     if diff $1 $2; then
+     if diff -Z $1 $2; then
           echo ok
      else
           FAILURES=$(expr $FAILURES + 1);

--- a/test/complement/test-complement.sh
+++ b/test/complement/test-complement.sh
@@ -19,10 +19,13 @@ check()
 ###########################################################
 echo -e "    complement.t1...\c"
 echo "chr1	1	20" > exp
-$BT complement -i <(echo -e "chr1\t0\t1") \
-               -g <(echo -e "chr1\t20") \
+echo -e "chr1\t0\t1" > tmp1
+echo -e "chr1\t20"   > tmp2
+$BT complement -i tmp1 \
+               -g tmp2 \
                > obs
 check obs exp
+rm tmp1 tmp2
 rm obs exp
 
 
@@ -31,10 +34,13 @@ rm obs exp
 ###########################################################
 echo -e "    complement.t2...\c"
 echo "chr1	1	19" > exp
-$BT complement -i <(echo -e "chr1\t0\t1\nchr1\t19\t20") \
-               -g <(echo -e "chr1\t20") \
+echo -e "chr1\t0\t1\nchr1\t19\t20" > tmp1
+echo -e "chr1\t20"                 > tmp2
+$BT complement -i tmp1 \
+               -g tmp2 \
                > obs
 check obs exp
+rm tmp1 tmp2
 rm obs exp
 
 ###########################################################
@@ -43,10 +49,13 @@ rm obs exp
 echo -e "    complement.t3...\c"
 echo "chr1	0	10
 chr1	15	20" > exp
-$BT complement -i <(echo -e "chr1\t10\t15") \
-               -g <(echo -e "chr1\t20") \
+echo -e "chr1\t10\t15" > tmp1
+echo -e "chr1\t20"     > tmp2
+$BT complement -i tmp1 \
+               -g tmp2 \
                > obs
 check obs exp
+rm tmp1 tmp2
 rm obs exp
 
 ###########################################################
@@ -54,10 +63,13 @@ rm obs exp
 ###########################################################
 echo -e "    complement.t4...\c"
 touch exp
-$BT complement -i <(echo -e "chr1\t0\t20") \
-               -g <(echo -e "chr1\t20") \
+echo -e "chr1\t0\t20" > tmp1
+echo -e "chr1\t20"    > tmp2
+$BT complement -i tmp1 \
+               -g tmp2 \
                > obs
 check obs exp
+rm tmp1 tmp2
 rm obs exp
 
 
@@ -66,10 +78,13 @@ rm obs exp
 ###########################################################
 echo -e "    complement.t5...\c"
 echo "chr1	0	20" > exp
-$BT complement -i <(echo -e "chr2\t0\t20") \
-               -g <(echo -e "chr1\t20\nchr2\t20") \
+echo -e "chr2\t0\t20"          > tmp1
+echo -e "chr1\t20\nchr2\t20"   > tmp2
+$BT complement -i tmp1 \
+               -g tmp2 \
                > obs
 check obs exp
+rm tmp1 tmp2
 rm obs exp
 
 ###########################################################
@@ -77,10 +92,13 @@ rm obs exp
 ###########################################################
 echo -e "    complement.t6...\c"
 echo "chr1	10000	249250621" > exp
-$BT complement -i <(echo -e "chr1\t0\t10000\ttelomere") \
-               -g <(echo -e "chr1\t249250621") \
+echo -e "chr1\t0\t10000\ttelomere" > tmp1
+echo -e "chr1\t249250621"          > tmp2
+$BT complement -i tmp1 \
+               -g tmp2 \
                > obs
 check obs exp
+rm tmp1 tmp2
 rm obs exp
 
 ###########################################################
@@ -89,10 +107,13 @@ rm obs exp
 echo -e "    complement.t7...\c"
 echo "chr1	0	10
 chr2	0	10" > exp
-$BT complement -i <(echo -e "chr1\t10\t20\nchr2\t10\t20") \
-               -g <(echo -e "chr1\t20\nchr2\t20") \
+echo -e "chr1\t10\t20\nchr2\t10\t20" > tmp1
+echo -e "chr1\t20\nchr2\t20"         > tmp2
+$BT complement -i tmp1 \
+               -g tmp2 \
                > obs
 check obs exp
+rm tmp1 tmp2
 rm obs exp
 
 ###########################################################
@@ -100,10 +121,13 @@ rm obs exp
 ###########################################################
 echo -e "    complement.t8...\c"
 echo "chr2	0	10" > exp
-$BT complement -i <(echo -e "chr1\t0\t20\nchr2\t10\t20") \
-               -g <(echo -e "chr1\t20\nchr2\t20") \
+echo -e "chr1\t0\t20\nchr2\t10\t20" > tmp1
+echo -e "chr1\t20\nchr2\t20"        > tmp2
+$BT complement -i tmp1 \
+               -g tmp2 \
                > obs
 check obs exp
+rm tmp1 tmp2
 rm obs exp
 
 ###########################################################
@@ -111,10 +135,13 @@ rm obs exp
 ###########################################################
 echo -e "    complement.t9...\c"
 echo -e "***** WARNING: chr1:90-110 exceeds the length of chromosome (chr1)\nchr1\t0\t90" > exp
-$BT complement -i <(echo -e "chr1\t90\t110") \
-               -g <(echo -e "chr1\t100") \
+echo -e "chr1\t90\t110" > tmp1
+echo -e "chr1\t100"     > tmp2
+$BT complement -i tmp1 \
+               -g tmp2 \
                &> obs
 check obs exp
+rm tmp1 tmp2
 rm obs exp
 [[ $FAILURES -eq 0 ]] || exit 1;
 

--- a/test/coverage/test-coverage.sh
+++ b/test/coverage/test-coverage.sh
@@ -6,7 +6,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 	else
     	FAILURES=$(expr $FAILURES + 1);

--- a/test/expand/test-expand.sh
+++ b/test/expand/test-expand.sh
@@ -5,7 +5,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 
 	else

--- a/test/fisher/test-fisher.sh
+++ b/test/fisher/test-fisher.sh
@@ -5,7 +5,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 
 	else

--- a/test/fisher/test-fisher.sh
+++ b/test/fisher/test-fisher.sh
@@ -102,7 +102,7 @@ rm obs exp
 echo -e "    fisher.t5...\c"
 $BT fisher -b test.bed -a tumor.gff -g dm6.fai > exp
 DIR="${TMPDIR:-/tmp}/Users/mvandenb/src/genomic_features_bardin_lab/build/modencode/dm6/bed/"
-LONG_PATH="$DIR/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaS-\(phospho-S2\)_.bed"
+LONG_PATH="$DIR/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaS-phospho-S2_.bed"
 mkdir -p "$DIR"
 cp test.bed "$LONG_PATH"
 $BT fisher -b "$LONG_PATH" -a tumor.gff -g dm6.fai > obs

--- a/test/flank/test-flank.sh
+++ b/test/flank/test-flank.sh
@@ -5,7 +5,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 
 	else

--- a/test/general/test-general.sh
+++ b/test/general/test-general.sh
@@ -5,7 +5,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
 		echo ok
 	else
 		FAILURES=$(expr $FAILURES + 1);

--- a/test/genomecov/test-genomecov.sh
+++ b/test/genomecov/test-genomecov.sh
@@ -6,7 +6,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 	else
     	FAILURES=$(expr $FAILURES + 1);

--- a/test/getfasta/test-getfasta.sh
+++ b/test/getfasta/test-getfasta.sh
@@ -216,8 +216,10 @@ rm obs exp
 echo -e "    getfasta.t134..\c"
 echo ">chr1:0-1
 a" > exp
-$BT getfasta -fi t.fa -bed <(echo -e "chr1\t0\t1") > obs
+echo -e "chr1\t0\t1" > tmp1
+$BT getfasta -fi t.fa -bed tmp1 > obs
 check obs exp
+rm tmp1
 rm obs exp
 [[ $FAILURES -eq 0 ]] || exit 1;
 

--- a/test/getfasta/test-getfasta.sh
+++ b/test/getfasta/test-getfasta.sh
@@ -13,7 +13,7 @@ FAILURES=0;
 
 check()
 {
-    if diff $1 $2; then
+    if diff -Z $1 $2; then
         echo ok
     else
         FAILURES=$(expr $FAILURES + 1);

--- a/test/groupby/test-groupby.sh
+++ b/test/groupby/test-groupby.sh
@@ -5,7 +5,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 
 	else

--- a/test/intersect/multi_intersect/test-multi_intersect.sh
+++ b/test/intersect/multi_intersect/test-multi_intersect.sh
@@ -13,7 +13,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 	else
     	FAILURES=$(expr $FAILURES + 1);

--- a/test/intersect/new_test-intersect.sh
+++ b/test/intersect/new_test-intersect.sh
@@ -21,7 +21,7 @@ bam_check()
 	then
 		echo ok
 	else
-		FAILURES$(expr $FAILURES + 1);
+		FAILURES=$(expr $FAILURES + 1);
 		echo fail
 	fi
 	rm b1 b2

--- a/test/intersect/new_test-intersect.sh
+++ b/test/intersect/new_test-intersect.sh
@@ -15,13 +15,16 @@ check()
 
 bam_check() 
 {
-	if diff -Z <($htsutil viewbamrecords $1) <($htsutil viewbamrecords $2)
+  $htsutil viewbamrecords $1 > b1
+  $htsutil viewbamrecords $2 > b2
+	if diff -Z b1 b2
 	then
 		echo ok
 	else
 		FAILURES$(expr $FAILURES + 1);
 		echo fail
 	fi
+	rm b1 b2
 }
 
 ###########################################################

--- a/test/intersect/new_test-intersect.sh
+++ b/test/intersect/new_test-intersect.sh
@@ -5,7 +5,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 	else
     	FAILURES=$(expr $FAILURES + 1);
@@ -15,7 +15,7 @@ check()
 
 bam_check() 
 {
-	if diff <($htsutil viewbamrecords $1) <($htsutil viewbamrecords $2)
+	if diff -Z <($htsutil viewbamrecords $1) <($htsutil viewbamrecords $2)
 	then
 		echo ok
 	else

--- a/test/intersect/new_test-intersect.sh
+++ b/test/intersect/new_test-intersect.sh
@@ -64,18 +64,6 @@ rm obs exp
 
 
 ###########################################################
-#  Test intersection of a as bed from fifo vs b as bed from file
-############################################################
-echo -e "    intersect.new.t04...\c"
-echo \
-"chr1	100	101	a2	2	-
-chr1	100	110	a2	2	-" > exp
-$BT intersect -a <(cat a.bed) -b b.bed > obs
-check obs exp
-rm obs exp
-
-
-###########################################################
 #  Test intersection of a as gzipped from file vs b as bed from file
 ############################################################
 echo -e "    intersect.new.t05...\c"
@@ -107,18 +95,6 @@ echo \
 "chr1	100	101	a2	2	-
 chr1	100	110	a2	2	-" > exp
 cat a_gzipped.bed.gz | $BT intersect -a - -b b.bed > obs
-check obs exp
-rm obs exp
-
-
-###########################################################
-#  Test intersection of a as gzipped from fifo vs b as bed from file
-############################################################
-echo -e "    intersect.new.t08...\c"
-echo \
-"chr1	100	101	a2	2	-
-chr1	100	110	a2	2	-" > exp
-$BT intersect -a <(cat a_gzipped.bed.gz) -b b.bed > obs
 check obs exp
 rm obs exp
 
@@ -158,27 +134,13 @@ cat a_bgzipped.bed.gz | $BT intersect -a - -b b.bed > obs
 check obs exp
 rm obs exp
 
-
-###########################################################
-#  Test intersection of a as bgzipped from fifo vs b as bed from file
-############################################################
-echo -e "    intersect.new.t12...\c"
-echo \
-"chr1	100	101	a2	2	-
-chr1	100	110	a2	2	-" > exp
-$BT intersect -a <(cat a_bgzipped.bed.gz) -b b.bed > obs
-check obs exp
-rm obs exp
-
-
 ###########################################################
 #  Test intersection of a as bam from file vs b as bed from file
 ############################################################
 echo -e "    intersect.new.t13...\c"
-$BT intersect -a a.bam -b b.bed> obs
+$BT intersect -a a.bam -b b.bed > obs
 bam_check obs aVSb.bam
 rm obs
-
 
 ###########################################################
 #  Test intersection of a as bam from redirect vs b as bed from file
@@ -188,21 +150,11 @@ $BT intersect -a - -b b.bed < a.bam> obs
 bam_check obs aVSb.bam
 rm obs
 
-
 ###########################################################
 #  Test intersection of a as bam from pipe vs b as bed from file
 ############################################################
 echo -e "    intersect.new.t15...\c"
 cat a.bam | $BT intersect -a - -b b.bed> obs
-bam_check obs aVSb.bam
-rm obs
-
-
-###########################################################
-#  Test intersection of a as bam from fifo vs b as bed from file
-############################################################
-echo -e "    intersect.new.t16...\c"
-$BT intersect -a <(cat a.bam) -b b.bed > obs
 bam_check obs aVSb.bam
 rm obs
 
@@ -370,17 +322,6 @@ check obs exp
 rm obs exp
 
 
-###########################################################
-#  Test intersection of a with large header as bed from fifo vs b as bed from file
-############################################################
-echo -e "    intersect.new.t27...\c"
-echo \
-"chr1	100	101	a2	2	-
-chr1	100	110	a2	2	-" > exp
-$BT intersect -a <(cat a_withLargeHeader.bed) -b b.bed > obs
-check obs exp
-rm obs exp
-
 
 ###########################################################
 #  Test intersection of a with large header as gzipped from file vs b as bed from file
@@ -417,17 +358,6 @@ cat a_withLargeHeader_gzipped.bed.gz | $BT intersect -a - -b b.bed > obs
 check obs exp
 rm obs exp
 
-
-###########################################################
-#  Test intersection of a with large header as gzipped from fifo vs b as bed from file
-############################################################
-echo -e "    intersect.new.t31...\c"
-echo \
-"chr1	100	101	a2	2	-
-chr1	100	110	a2	2	-" > exp
-$BT intersect -a <(cat a_withLargeHeader_gzipped.bed.gz) -b b.bed > obs
-check obs exp
-rm obs exp
 
 
 ###########################################################
@@ -467,18 +397,6 @@ rm obs exp
 
 
 ###########################################################
-#  Test intersection of a with large header as bgzipped from fifo vs b as bed from file
-############################################################
-echo -e "    intersect.new.t35...\c"
-echo \
-"chr1	100	101	a2	2	-
-chr1	100	110	a2	2	-" > exp
-$BT intersect -a <(cat a_withLargeHeader_bgzipped.bed.gz) -b b.bed > obs
-check obs exp
-rm obs exp
-
-
-###########################################################
 #  Test intersection of a with large header as bed from file 
 #  vs b as bed from file, and print header
 ############################################################
@@ -507,15 +425,6 @@ cat a_withLargeHeader.bed | $BT intersect -a - -b b.bed -header > obs
 check obs aWithHeaderVsB.txt
 rm obs
 
-
-###########################################################
-#  Test intersection of a with large header as bed from fifo
-#  vs b as bed from file, and print header
-############################################################
-echo -e "    intersect.new.t39...\c"
-$BT intersect -a <(cat a_withLargeHeader.bed) -b b.bed -header > obs
-check obs aWithHeaderVsB.txt
-rm obs
 
 
 ###########################################################
@@ -548,15 +457,6 @@ check obs aWithHeaderVsB.txt
 rm obs
 
 
-###########################################################
-#  Test intersection of a with large header as gzipped from
-#  fifo vs b as bed from file, and print header
-############################################################
-echo -e "    intersect.new.t43...\c"
-$BT intersect -a <(cat a_withLargeHeader_gzipped.bed.gz) -b b.bed -header > obs
-check obs aWithHeaderVsB.txt
-rm obs
-
 
 ###########################################################
 #  Test intersection of a with large header as bgzipped from
@@ -584,16 +484,6 @@ rm obs
 ############################################################
 echo -e "    intersect.new.t46...\c"
 cat a_withLargeHeader_bgzipped.bed.gz | $BT intersect -a - -b b.bed -header > obs
-check obs aWithHeaderVsB.txt
-rm obs
-
-
-###########################################################
-#  Test intersection of a with large header as bgzipped from
-#  fifo vs b as bed from file, and print header
-############################################################
-echo -e "    intersect.new.t47...\c"
-$BT intersect -a <(cat a_withLargeHeader_bgzipped.bed.gz) -b b.bed -header > obs
 check obs aWithHeaderVsB.txt
 rm obs
 

--- a/test/intersect/sortAndNaming/test-sort-and-naming.sh
+++ b/test/intersect/sortAndNaming/test-sort-and-naming.sh
@@ -13,7 +13,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
             echo ok
 	else
             FAILURES=$(expr $FAILURES + 1);

--- a/test/intersect/test-intersect.sh
+++ b/test/intersect/test-intersect.sh
@@ -1065,65 +1065,81 @@ rm exp obs
 # BED        -----------
 echo -e "    intersect.t72...\c"
 echo "1	.	.	16	20	.	-	.	." > exp
-$BT intersect -a <(echo -e  "1\t.\t.\t10\t20\t.\t-\t.\t.") -b <(echo -e  "1\t15\t25") > obs
+echo -e  "1\t.\t.\t10\t20\t.\t-\t.\t." > t1
+echo -e  "1\t15\t25" > t2
+$BT intersect -a t1 -b t2 > obs
 check exp obs
-rm exp obs
+rm exp obs t1 t2
 
 # BED   ----------
 # GFF        -----------
 echo -e "    intersect.t73...\c"
 echo "1	15	20" > exp
-$BT intersect -a <(echo -e  "1\t15\t25") -b <(echo -e  "1\t.\t.\t10\t20\t.\t-\t.\t.")  > obs
+echo -e  "1\t15\t25" > t1
+echo -e  "1\t.\t.\t10\t20\t.\t-\t.\t." > t2
+$BT intersect -a t1 -b t2 > obs
 check exp obs
-rm exp obs
+rm exp obs t1 t2
 
 # GFF        ----------
 # BED    -----------
 echo -e "    intersect.t74...\c"
 echo "1	.	.	15	20	.	-	.	." > exp
-$BT intersect -a <(echo -e  "1\t.\t.\t15\t25\t.\t-\t.\t.") -b <(echo -e  "1\t10\t20") > obs
+echo -e  "1\t.\t.\t15\t25\t.\t-\t.\t." > t1
+echo -e  "1\t10\t20" > t2
+$BT intersect -a t1 -b t2 > obs
 check exp obs
-rm exp obs
+rm exp obs t1 t2
 
 # BED        ----------
 # GFF    -----------
 echo -e "    intersect.t75...\c"
 echo "1	15	20" > exp
-$BT intersect  -a <(echo -e  "1\t15\t25") -b <(echo -e  "1\t.\t.\t10\t20\t.\t-\t.\t.") > obs
+echo -e  "1\t15\t25" > t1
+echo -e  "1\t.\t.\t10\t20\t.\t-\t.\t." > t2
+$BT intersect  -a t1 -b t2 > obs
 check exp obs
-rm exp obs
+rm exp obs t1 t2
 
 # GFF        ----------
 # BED    -------------------
 echo -e "    intersect.t76...\c"
 echo "1	.	.	15	20	.	-	.	." > exp
-$BT intersect -a <(echo -e  "1\t.\t.\t15\t20\t.\t-\t.\t.") -b <(echo -e  "1\t10\t25") > obs
+echo -e  "1\t.\t.\t15\t20\t.\t-\t.\t." > t1
+echo -e  "1\t10\t25" > t2
+$BT intersect -a t1 -b t2 > obs
 check exp obs
-rm exp obs
+rm exp obs t1 t2
 
 # BED        ----------
 # GFF    --------------------
 echo -e "    intersect.t77...\c"
 echo "1	15	20" > exp
-$BT intersect -a <(echo -e "1\t15\t20") -b <(echo -e "1\t.\t.\t10\t25\t.\t-\t.\t.")  > obs
+echo -e "1\t15\t20" > t1
+echo -e "1\t.\t.\t10\t25\t.\t-\t.\t." > t2
+$BT intersect -a t1 -b t2  > obs
 check exp obs
-rm exp obs
+rm exp obs t1 t2
 
 # GFF        ----------
 # BED    -------------------
 echo -e "    intersect.t78...\c"
 echo "1	.	.	16	20	.	-	.	." > exp
-$BT intersect -a <(echo -e "1\t.\t.\t10\t25\t.\t-\t.\t.") -b <(echo -e "1\t15\t20") > obs
+echo -e "1\t.\t.\t10\t25\t.\t-\t.\t." > t1
+echo -e "1\t15\t20" > t2
+$BT intersect -a t1 -b t2 > obs
 check exp obs
-rm exp obs
+rm exp obs t1 t2
 
 # BED        ----------
 # GFF    --------------------
 echo -e "    intersect.t79...\c"
 echo "1	14	20" > exp
-$BT intersect -a <(echo -e "1\t10\t25") -b <(echo -e "1\t.\t.\t15\t20\t.\t-\t.\t.")  > obs
+echo -e "1\t10\t25" > t1
+echo -e "1\t.\t.\t15\t20\t.\t-\t.\t." > t2
+$BT intersect -a t1 -b t2  > obs
 check exp obs
-rm exp obs
+rm exp obs t1 t2
 
 # Make sure 1bp of overlap is reported for a VCF SNP and 1-bp overlapping BED.
 echo -e "    intersect.t80...\c"

--- a/test/intersect/test-intersect.sh
+++ b/test/intersect/test-intersect.sh
@@ -7,7 +7,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
 		echo ok
 	else
 		FAILURES=$(expr $FAILURES + 1);

--- a/test/jaccard/test-jaccard.sh
+++ b/test/jaccard/test-jaccard.sh
@@ -5,7 +5,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 	else
     	FAILURES=$(expr $FAILURES + 1);

--- a/test/makewindows/test-makewindows.sh
+++ b/test/makewindows/test-makewindows.sh
@@ -5,7 +5,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 	else
     	FAILURES=$(expr $FAILURES + 1);

--- a/test/map/test-map.sh
+++ b/test/map/test-map.sh
@@ -5,7 +5,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 	else
     	FAILURES=$(expr $FAILURES + 1);

--- a/test/merge/test-merge.sh
+++ b/test/merge/test-merge.sh
@@ -5,7 +5,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 
 	else

--- a/test/multicov/test-multicov.sh
+++ b/test/multicov/test-multicov.sh
@@ -6,7 +6,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 	else
     	FAILURES=$(expr $FAILURES + 1);

--- a/test/reldist/test-reldist.sh
+++ b/test/reldist/test-reldist.sh
@@ -6,7 +6,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 	else
     	FAILURES=$(expr $FAILURES + 1);

--- a/test/sample/test-sample.sh
+++ b/test/sample/test-sample.sh
@@ -11,7 +11,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 	else
     	FAILURES=$(expr $FAILURES + 1);

--- a/test/shift/test-shift.sh
+++ b/test/shift/test-shift.sh
@@ -5,7 +5,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 
 	else

--- a/test/shuffle/test-shuffle.sh
+++ b/test/shuffle/test-shuffle.sh
@@ -4,7 +4,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 
 	else

--- a/test/shuffle/test-shuffle.sh
+++ b/test/shuffle/test-shuffle.sh
@@ -135,7 +135,10 @@ rm obs exp
 ###############################################################
 echo -e "    shuffle.t6...\c"
 echo "Error, line 1: tried 1000 potential loci for entry, but could not avoid excluded regions.  Ignoring entry and moving on." > exp
-$BT shuffle -i <(echo -e "chr1\t0\t110") -g <(echo -e "chr1\t100") &> obs
+echo -e "chr1\t0\t110" > t1
+echo -e "chr1\t100" > t2
+$BT shuffle -i t1 -g t2 &> obs
 check obs exp
-rm obs exp
+rm obs exp t1 t2
 [[ $FAILURES -eq 0 ]] || exit 1;
+

--- a/test/slop/test-slop.sh
+++ b/test/slop/test-slop.sh
@@ -5,7 +5,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 
 	else

--- a/test/sort/test-sort.sh
+++ b/test/sort/test-sort.sh
@@ -5,7 +5,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 	else
     	FAILURES=$(expr $FAILURES + 1);

--- a/test/spacing/test-spacing.sh
+++ b/test/spacing/test-spacing.sh
@@ -5,7 +5,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 	else
     	FAILURES=$(expr $FAILURES + 1);

--- a/test/split/test-split.sh
+++ b/test/split/test-split.sh
@@ -4,7 +4,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 
 	else

--- a/test/subtract/test-subtract.sh
+++ b/test/subtract/test-subtract.sh
@@ -5,7 +5,7 @@ FAILURES=0;
 
 check()
 {
-	if diff $1 $2; then
+	if diff -Z $1 $2; then
     	echo ok
 	else
     	FAILURES=$(expr $FAILURES + 1);


### PR DESCRIPTION
Unlike the previous MSYS PR, which requires cygwin/msys's C library, this is an honest to god port of bedtools2 to the windows C runtime.

Some tests will fail when run in minpty but will work perfectly fine when run from a windows conpty, not entirely sure the best way to fix that. Additionally, the makefile doesn't actually install the libraries alongside the executable, which is...kind of important.

Aside from that, its late and I'll be online tomorrow.