### PR TITLE
python is python3 on most modern unix platforms

### DIFF
--- a/test/genomecov/mk-deep.py
+++ b/test/genomecov/mk-deep.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 print("""\
 @HD\tVN:1.0\tSO:coordinate
 @SQ\tSN:c1\tAS:genome.txt\tLN:100""")

--- a/test/genomecov/test-genomecov.sh
+++ b/test/genomecov/test-genomecov.sh
@@ -288,7 +288,7 @@ CRAM_REFERENCE=test_ref.fa $BT genomecov -ibam empty.cram > obs
 check obs exp
 rm obs exp
 
-python mk-deep.py > deep.sam
+python3 mk-deep.py > deep.sam
 echo -e "    genomecov.t18...\c"
 echo "c1	1	1000000" > exp
 $BT genomecov -d -ibam deep.sam | head -1 > obs


### PR DESCRIPTION
Executable for python3 is mostly named python3 on modern linux platforms. Calling out to python breaks genomecov test.