### PR TITLE
add cstdint for uint64_t support

### DIFF
--- a/src/utils/BamTools/include/api/BamAux.h
+++ b/src/utils/BamTools/include/api/BamAux.h
@@ -1,4 +1,5 @@
 #include <string>
+#include <cstdint>
 
 #ifndef BAMAUX_H
 #define BAMAUX_H

--- a/src/utils/lineFileUtilities/lineFileUtilities.h
+++ b/src/utils/lineFileUtilities/lineFileUtilities.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <cstring>
 #include <cstdlib>
+#include <cstdint>
 #include <sstream>
 #include <iostream>
 

--- a/src/utils/sequenceUtilities/sequenceUtils.h
+++ b/src/utils/sequenceUtilities/sequenceUtils.h
@@ -1,6 +1,7 @@
 #ifndef SEQUENCEUTILS_H
 #define SEQUENCEUTILS_H
 
+#include <cstdint>
 #include <string>
 #include <algorithm>
 #include <cctype>


### PR DESCRIPTION
This PR covers a set of compile time errors from no declaration for uint64_t's; header for cstdint added to respective files. Environment as noted below. Unclear if/why this is a specific issue for this architecture/build tools given stable builds from upstream. 

edit: typos
//
Architecture: Docker with Alpine Linux (as below)
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-alpine-linux-musl/15.2.0/lto-wrapper
Target: x86_64-alpine-linux-musl
Configured with: /home/buildozer/aports/main/gcc/src/gcc-15.2.0/configure --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --build=x86_64-alpine-linux-musl --host=x86_64-alpine-linux-musl --target=x86_64-alpine-linux-musl --enable-checking=release --disable-cet --disable-fixed-point --disable-libstdcxx-pch --disable-multilib --disable-nls --disable-werror --disable-symvers --enable-__cxa_atexit --enable-default-pie --enable-default-ssp --enable-languages=c,c++,d,objc,go,fortran,ada --enable-link-serialization=2 --enable-linker-build-id --disable-libssp --enable-libsanitizer --enable-shared --enable-threads --enable-tls --with-bugurl=https://gitlab.alpinelinux.org/alpine/aports/-/issues --with-system-zlib --with-linker-hash-style=gnu --with-pkgversion='Alpine 15.2.0'
Thread model: posix
Supported LTO compression algorithms: zlib
gcc version 15.2.0 (Alpine 15.2.0)